### PR TITLE
feat: enhance file entries and scanning

### DIFF
--- a/FirmwarePackager/src/core/Packager.cpp
+++ b/FirmwarePackager/src/core/Packager.cpp
@@ -14,6 +14,7 @@ Packager::Packager(Scanner& s, Hasher& h, IManifestWriter& m,
 
 Project Packager::buildProject(const std::filesystem::path& root, const Scanner::PathList& exclusions) {
     Project project(root.filename().string());
+    project.rootDir = root;
     auto paths = scanner.scan(root, exclusions);
     for (const auto& p : paths) {
         std::ifstream in(p, std::ios::binary);
@@ -29,6 +30,7 @@ Project Packager::buildProject(const std::filesystem::path& root, const Scanner:
 void Packager::package(const std::filesystem::path& root, const std::filesystem::path& outdir, const Scanner::PathList& exclusions) {
     logger.info("Packaging project");
     Project project = buildProject(root, exclusions);
+    project.outputDir = outdir;
     std::filesystem::create_directories(outdir);
     for (const auto& f : project.files) {
         auto src = root / f.path;

--- a/FirmwarePackager/src/core/ProjectModel.cpp
+++ b/FirmwarePackager/src/core/ProjectModel.cpp
@@ -2,14 +2,17 @@
 
 namespace core {
 
-FileEntry::FileEntry() = default;
+FileEntry::FileEntry()
+    : recursive(false) {}
 
 FileEntry::FileEntry(std::filesystem::path p, std::string i, std::string h)
-    : path(std::move(p)), id(std::move(i)), hash(std::move(h)) {}
+    : path(std::move(p)), dest(path), id(std::move(i)), hash(std::move(h)),
+      mode(""), owner(""), group(""), recursive(false) {}
 
 Project::Project() = default;
 
-Project::Project(std::string name) : name(std::move(name)) {}
+Project::Project(std::string name)
+    : name(std::move(name)) {}
 
 } // namespace core
 

--- a/FirmwarePackager/src/core/ProjectModel.h
+++ b/FirmwarePackager/src/core/ProjectModel.h
@@ -8,15 +8,24 @@ namespace core {
 
 struct FileEntry {
     std::filesystem::path path;   // location on disk
+    std::filesystem::path dest;   // destination inside package
     std::string id;               // generated identifier
     std::string hash;             // md5 hash
+    std::string mode;             // file mode
+    std::string owner;            // file owner
+    std::string group;            // file group
+    bool recursive;               // whether to traverse directories
+    std::vector<std::filesystem::path> excludes; // paths to exclude
 
     FileEntry();
     FileEntry(std::filesystem::path p, std::string i, std::string h);
 };
 
 struct Project {
-    std::string name;                 // project name
+    std::string name;                 // project/package name
+    std::string version;              // package version
+    std::filesystem::path rootDir;    // project root directory
+    std::filesystem::path outputDir;  // output directory
     std::vector<FileEntry> files;     // files included in project
 
     Project();

--- a/FirmwarePackager/src/core/Scanner.cpp
+++ b/FirmwarePackager/src/core/Scanner.cpp
@@ -4,7 +4,7 @@
 
 namespace core {
 
-Scanner::PathList Scanner::scan(const std::filesystem::path& root, const PathList& exclusions) const {
+Scanner::PathList Scanner::scan(const std::filesystem::path& root, const PathList& exclusions, bool recursive) const {
     PathList result;
     if (!std::filesystem::exists(root)) {
         return result;
@@ -17,18 +17,40 @@ Scanner::PathList Scanner::scan(const std::filesystem::path& root, const PathLis
     }
 
     std::error_code ec;
-    std::filesystem::recursive_directory_iterator it(root, ec), end;
-    for (; it != end; it.increment(ec)) {
-        if (ec) break;
-        const auto& p = it->path();
-        if (isExcluded(p, absEx)) {
-            if (it->is_directory()) {
-                it.disable_recursion_pending();
-            }
-            continue;
+
+    if (std::filesystem::is_regular_file(root)) {
+        if (!isExcluded(root, absEx)) {
+            result.push_back(root);
         }
-        if (it->is_regular_file()) {
-            result.push_back(p);
+        return result;
+    }
+
+    if (recursive) {
+        std::filesystem::recursive_directory_iterator it(root, ec), end;
+        for (; it != end; it.increment(ec)) {
+            if (ec) break;
+            const auto& p = it->path();
+            if (isExcluded(p, absEx)) {
+                if (it->is_directory()) {
+                    it.disable_recursion_pending();
+                }
+                continue;
+            }
+            if (it->is_regular_file()) {
+                result.push_back(p);
+            }
+        }
+    } else {
+        std::filesystem::directory_iterator it(root, ec), end;
+        for (; it != end; it.increment(ec)) {
+            if (ec) break;
+            const auto& p = it->path();
+            if (isExcluded(p, absEx)) {
+                continue;
+            }
+            if (std::filesystem::is_regular_file(p)) {
+                result.push_back(p);
+            }
         }
     }
     return result;

--- a/FirmwarePackager/src/core/Scanner.h
+++ b/FirmwarePackager/src/core/Scanner.h
@@ -10,8 +10,9 @@ class Scanner {
 public:
     using PathList = std::vector<std::filesystem::path>;
 
-    // Returns a list of all files under 'root' that are not excluded.
-    PathList scan(const std::filesystem::path& root, const PathList& exclusions) const;
+    // Returns a list of files under 'root' honoring exclusions. If 'recursive' is false
+    // only the top level is scanned.
+    PathList scan(const std::filesystem::path& root, const PathList& exclusions, bool recursive = true) const;
 
 private:
     bool isExcluded(const std::filesystem::path& path, const PathList& exclusions) const;

--- a/FirmwarePackager/src/ui/MainWindow.cpp
+++ b/FirmwarePackager/src/ui/MainWindow.cpp
@@ -11,6 +11,7 @@
 #include <QSplitter>
 #include <QAction>
 #include <QPushButton>
+#include <QStringList>
 
 MainWindow::MainWindow(QWidget* parent)
     : QMainWindow(parent), guiLogger(nullptr) {
@@ -18,10 +19,16 @@ MainWindow::MainWindow(QWidget* parent)
 
     auto *splitter = new QSplitter(Qt::Vertical, this);
 
-    model = new QStandardItemModel(0, 3, this);
+    model = new QStandardItemModel(0, 9, this);
     model->setHeaderData(0, Qt::Horizontal, "Path");
-    model->setHeaderData(1, Qt::Horizontal, "ID");
-    model->setHeaderData(2, Qt::Horizontal, "Hash");
+    model->setHeaderData(1, Qt::Horizontal, "Dest");
+    model->setHeaderData(2, Qt::Horizontal, "ID");
+    model->setHeaderData(3, Qt::Horizontal, "Mode");
+    model->setHeaderData(4, Qt::Horizontal, "Owner");
+    model->setHeaderData(5, Qt::Horizontal, "Group");
+    model->setHeaderData(6, Qt::Horizontal, "Recursive");
+    model->setHeaderData(7, Qt::Horizontal, "Excludes");
+    model->setHeaderData(8, Qt::Horizontal, "Hash");
 
     tableView = new QTableView;
     tableView->setModel(model);
@@ -85,8 +92,17 @@ void MainWindow::populateTable(const core::Project& project) {
     for (const auto& file : project.files) {
         model->insertRow(row);
         model->setData(model->index(row, 0), QString::fromStdString(file.path.string()));
-        model->setData(model->index(row, 1), QString::fromStdString(file.id));
-        model->setData(model->index(row, 2), QString::fromStdString(file.hash));
+        model->setData(model->index(row, 1), QString::fromStdString(file.dest.string()));
+        model->setData(model->index(row, 2), QString::fromStdString(file.id));
+        model->setData(model->index(row, 3), QString::fromStdString(file.mode));
+        model->setData(model->index(row, 4), QString::fromStdString(file.owner));
+        model->setData(model->index(row, 5), QString::fromStdString(file.group));
+        model->setData(model->index(row, 6), file.recursive ? "Yes" : "No");
+        QStringList exList;
+        for (const auto& ex : file.excludes)
+            exList << QString::fromStdString(ex.string());
+        model->setData(model->index(row, 7), exList.join(","));
+        model->setData(model->index(row, 8), QString::fromStdString(file.hash));
         ++row;
     }
 }
@@ -97,6 +113,7 @@ void MainWindow::openRoot() {
         return;
     rootEdit->setText(dir);
     currentProject = packager->buildProject(dir.toStdString(), core::Scanner::PathList{});
+    currentProject.outputDir = outputEdit->text().toStdString();
     populateTable(currentProject);
 }
 
@@ -105,6 +122,7 @@ void MainWindow::buildPackage() {
         QMessageBox::warning(this, "Missing Paths", "Please specify both root and output directories.");
         return;
     }
+    currentProject.outputDir = outputEdit->text().toStdString();
     packager->package(rootEdit->text().toStdString(), outputEdit->text().toStdString(), core::Scanner::PathList{});
 }
 
@@ -115,6 +133,7 @@ void MainWindow::openSettings() {
         outputEdit->setText(dlg.outputDir());
         if (!dlg.rootDir().isEmpty()) {
             currentProject = packager->buildProject(dlg.rootDir().toStdString(), core::Scanner::PathList{});
+            currentProject.outputDir = dlg.outputDir().toStdString();
             populateTable(currentProject);
         }
     }
@@ -130,7 +149,16 @@ void MainWindow::editMapping() {
     core::FileEntry& entry = currentProject.files[row];
     MappingDialog dlg(entry, this);
     if (dlg.exec() == QDialog::Accepted) {
-        model->setData(model->index(row, 1), QString::fromStdString(entry.id));
+        model->setData(model->index(row, 1), QString::fromStdString(entry.dest.string()));
+        model->setData(model->index(row, 2), QString::fromStdString(entry.id));
+        model->setData(model->index(row, 3), QString::fromStdString(entry.mode));
+        model->setData(model->index(row, 4), QString::fromStdString(entry.owner));
+        model->setData(model->index(row, 5), QString::fromStdString(entry.group));
+        model->setData(model->index(row, 6), entry.recursive ? "Yes" : "No");
+        QStringList exList;
+        for (const auto& ex : entry.excludes)
+            exList << QString::fromStdString(ex.string());
+        model->setData(model->index(row, 7), exList.join(","));
     }
 }
 

--- a/FirmwarePackager/src/ui/MappingDialog.cpp
+++ b/FirmwarePackager/src/ui/MappingDialog.cpp
@@ -2,6 +2,7 @@
 
 #include <QFormLayout>
 #include <QDialogButtonBox>
+#include <QStringList>
 
 MappingDialog::MappingDialog(core::FileEntry& entry, QWidget* parent)
     : QDialog(parent), fileEntry(entry) {
@@ -16,6 +17,28 @@ MappingDialog::MappingDialog(core::FileEntry& entry, QWidget* parent)
     idEdit = new QLineEdit(QString::fromStdString(fileEntry.id));
     layout->addRow("ID", idEdit);
 
+    destEdit = new QLineEdit(QString::fromStdString(fileEntry.dest.string()));
+    layout->addRow("Dest", destEdit);
+
+    modeEdit = new QLineEdit(QString::fromStdString(fileEntry.mode));
+    layout->addRow("Mode", modeEdit);
+
+    ownerEdit = new QLineEdit(QString::fromStdString(fileEntry.owner));
+    layout->addRow("Owner", ownerEdit);
+
+    groupEdit = new QLineEdit(QString::fromStdString(fileEntry.group));
+    layout->addRow("Group", groupEdit);
+
+    recursiveCheck = new QCheckBox;
+    recursiveCheck->setChecked(fileEntry.recursive);
+    layout->addRow("Recursive", recursiveCheck);
+
+    QStringList ex;
+    for (const auto& e : fileEntry.excludes)
+        ex << QString::fromStdString(e.string());
+    excludesEdit = new QLineEdit(ex.join(","));
+    layout->addRow("Excludes", excludesEdit);
+
     auto *buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttons, &QDialogButtonBox::accepted, this, &MappingDialog::accept);
     connect(buttons, &QDialogButtonBox::rejected, this, &MappingDialog::reject);
@@ -24,6 +47,16 @@ MappingDialog::MappingDialog(core::FileEntry& entry, QWidget* parent)
 
 void MappingDialog::accept() {
     fileEntry.id = idEdit->text().toStdString();
+    fileEntry.dest = destEdit->text().toStdString();
+    fileEntry.mode = modeEdit->text().toStdString();
+    fileEntry.owner = ownerEdit->text().toStdString();
+    fileEntry.group = groupEdit->text().toStdString();
+    fileEntry.recursive = recursiveCheck->isChecked();
+    fileEntry.excludes.clear();
+    const auto parts = excludesEdit->text().split(',', Qt::SkipEmptyParts);
+    for (const auto& p : parts) {
+        fileEntry.excludes.emplace_back(p.trimmed().toStdString());
+    }
     QDialog::accept();
 }
 

--- a/FirmwarePackager/src/ui/MappingDialog.h
+++ b/FirmwarePackager/src/ui/MappingDialog.h
@@ -2,6 +2,7 @@
 
 #include <QDialog>
 #include <QLineEdit>
+#include <QCheckBox>
 #include "src/core/ProjectModel.h"
 
 // Dialog for editing mapping information of a FileEntry
@@ -14,5 +15,11 @@ protected:
 private:
     core::FileEntry& fileEntry;
     QLineEdit* idEdit;
+    QLineEdit* destEdit;
+    QLineEdit* modeEdit;
+    QLineEdit* ownerEdit;
+    QLineEdit* groupEdit;
+    QCheckBox* recursiveCheck;
+    QLineEdit* excludesEdit;
 };
 


### PR DESCRIPTION
## Summary
- store destination, ownership, and recursion info for each file entry
- keep project metadata like version and output directory
- allow editing new file metadata and show it in the main table
- support non-recursive directory scans with per-entry exclusions

## Testing
- `apt-get update`
- `apt-get install -y qt5-qmake`
- `apt-get install -y qtbase5-dev`
- `qmake FirmwarePackager.pro`
- `make -j2` *(fails: 'BCRYPT_ALG_HANDLE' was not declared)*

------
https://chatgpt.com/codex/tasks/task_e_68bea5dbee708327aabe0ba8d1d761fd