### PR TITLE
feat: expand manifest writer with directory hashing

### DIFF
--- a/FirmwarePackager/src/core/ManifestWriter.cpp
+++ b/FirmwarePackager/src/core/ManifestWriter.cpp
@@ -1,17 +1,99 @@
 #include "ManifestWriter.h"
 
+#include <algorithm>
 #include <fstream>
+#include <iterator>
+#include <openssl/md5.h>
+#include <vector>
 
 namespace core {
+
+namespace {
+std::string toHex(const unsigned char* digest) {
+    static const char* hex = "0123456789abcdef";
+    std::string out;
+    out.reserve(32);
+    for (int i = 0; i < MD5_DIGEST_LENGTH; ++i) {
+        unsigned char b = digest[i];
+        out.push_back(hex[b >> 4]);
+        out.push_back(hex[b & 0xF]);
+    }
+    return out;
+}
+}
+
+std::string ManifestWriter::md5String(const std::string& data) {
+    unsigned char digest[MD5_DIGEST_LENGTH];
+    MD5(reinterpret_cast<const unsigned char*>(data.data()), data.size(), digest);
+    return toHex(digest);
+}
+
+std::string ManifestWriter::md5File(const std::filesystem::path& p) {
+    std::ifstream in(p, std::ios::binary);
+    if (!in.is_open()) return {};
+    MD5_CTX ctx; MD5_Init(&ctx);
+    char buf[4096];
+    while (in) {
+        in.read(buf, sizeof(buf));
+        std::streamsize s = in.gcount();
+        if (s > 0) MD5_Update(&ctx, buf, static_cast<size_t>(s));
+    }
+    unsigned char digest[MD5_DIGEST_LENGTH];
+    MD5_Final(digest, &ctx);
+    return toHex(digest);
+}
 
 void ManifestWriter::write(const Project& project, const std::filesystem::path& output) const {
     std::ofstream out(output);
     if (!out.is_open()) {
         return;
     }
-    out << "path\tid\thash\n";
+    out << "relpath\tdest\tmode\towner\tgroup\tmd5\n";
+
     for (const auto& f : project.files) {
-        out << f.path.string() << '\t' << f.id << '\t' << f.hash << '\n';
+        auto abs = project.rootDir / f.path;
+        if (f.recursive || std::filesystem::is_directory(abs)) {
+            struct Rec { std::filesystem::path rel; std::filesystem::path dest; std::string hash; };
+            std::vector<Rec> files;
+            if (std::filesystem::exists(abs)) {
+                for (auto& entry : std::filesystem::recursive_directory_iterator(abs)) {
+                    if (!entry.is_regular_file()) continue;
+                    auto rel = std::filesystem::relative(entry.path(), project.rootDir);
+                    auto relToDir = std::filesystem::relative(entry.path(), abs);
+                    auto dest = f.dest / relToDir;
+                    std::string h = md5File(entry.path());
+                    files.push_back({rel, dest, h});
+                }
+            }
+            std::sort(files.begin(), files.end(), [](const Rec& a, const Rec& b){ return a.rel < b.rel; });
+            std::string concat;
+            concat.reserve(files.size() * 32);
+            for (const auto& r : files) concat += r.hash;
+            std::string dirHash = md5String(concat);
+            out << f.path.generic_string() << '\t'
+                << f.dest.generic_string() << '\t'
+                << f.mode << '\t'
+                << f.owner << '\t'
+                << f.group << '\t'
+                << dirHash << '\n';
+            for (const auto& r : files) {
+                out << r.rel.generic_string() << '\t'
+                    << r.dest.generic_string() << '\t'
+                    << f.mode << '\t'
+                    << f.owner << '\t'
+                    << f.group << '\t'
+                    << r.hash << '\n';
+            }
+        } else {
+            std::string hash = f.hash;
+            if (hash.empty()) hash = md5File(abs);
+            out << f.path.generic_string() << '\t'
+                << f.dest.generic_string() << '\t'
+                << f.mode << '\t'
+                << f.owner << '\t'
+                << f.group << '\t'
+                << hash << '\n';
+        }
     }
 }
 

--- a/FirmwarePackager/src/core/ManifestWriter.h
+++ b/FirmwarePackager/src/core/ManifestWriter.h
@@ -13,7 +13,16 @@ public:
 
 class ManifestWriter : public IManifestWriter {
 public:
+    // Write project manifest to output path.
+    // The manifest is a tab-separated file with the following columns:
+    //   relpath, dest, mode, owner, group and md5.
+    // Directory entries are expanded to file-level records and receive a
+    // virtual md5 calculated from their children.
     void write(const Project& project, const std::filesystem::path& output) const override;
+
+private:
+    static std::string md5File(const std::filesystem::path& p);
+    static std::string md5String(const std::string& data);
 };
 
 } // namespace core

--- a/tests/manifest_writer_test.cpp
+++ b/tests/manifest_writer_test.cpp
@@ -1,0 +1,76 @@
+#include <gtest/gtest.h>
+#include "core/ManifestWriter.h"
+#include "core/ProjectModel.h"
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <openssl/md5.h>
+
+using namespace std::filesystem;
+
+namespace {
+std::string toHex(const unsigned char* digest) {
+    static const char* hex = "0123456789abcdef";
+    std::string out; out.reserve(32);
+    for (int i=0;i<MD5_DIGEST_LENGTH;++i){ unsigned char b=digest[i]; out.push_back(hex[b>>4]); out.push_back(hex[b&0xF]); }
+    return out;
+}
+std::string md5File(const path& p){
+    std::ifstream in(p, std::ios::binary); if(!in) return {};
+    MD5_CTX ctx; MD5_Init(&ctx); char buf[4096];
+    while(in){ in.read(buf,sizeof(buf)); std::streamsize s=in.gcount(); if(s>0) MD5_Update(&ctx,buf,static_cast<size_t>(s)); }
+    unsigned char d[MD5_DIGEST_LENGTH]; MD5_Final(d,&ctx); return toHex(d);
+}
+std::string md5String(const std::string& s){ unsigned char d[MD5_DIGEST_LENGTH]; MD5((const unsigned char*)s.data(), s.size(), d); return toHex(d);} 
+}
+
+TEST(ManifestWriterTest, ExpandsDirectoriesAndWritesColumns){
+    auto tmp = temp_directory_path()/"fp_test";
+    remove_all(tmp);
+    create_directories(tmp/"dir"/"sub");
+    { std::ofstream(tmp/"dir"/"a.txt")<<"hello"; }
+    { std::ofstream(tmp/"dir"/"sub"/"b.txt")<<"world"; }
+
+    core::Project project; project.rootDir = tmp;
+    core::FileEntry fe; fe.path="dir"; fe.dest="destdir"; fe.mode="0644"; fe.owner="root"; fe.group="root"; fe.recursive=true; project.files.push_back(fe);
+
+    core::ManifestWriter writer;
+    auto manifestPath = tmp/"manifest.tsv";
+    writer.write(project, manifestPath);
+
+    std::ifstream in(manifestPath);
+    ASSERT_TRUE(in.is_open());
+    std::vector<std::vector<std::string>> lines; std::string line;
+    while(std::getline(in,line)){
+        std::vector<std::string> cols; std::stringstream ss(line); std::string c; while(std::getline(ss,c,'\t')) cols.push_back(c); lines.push_back(cols); }
+
+    ASSERT_EQ(lines.size(), 4u);
+    EXPECT_EQ(lines[0], (std::vector<std::string>{"relpath","dest","mode","owner","group","md5"}));
+
+    std::string hashA = md5File(tmp/"dir"/"a.txt");
+    std::string hashB = md5File(tmp/"dir"/"sub"/"b.txt");
+    std::string dirHash = md5String(hashA + hashB);
+
+    auto dirLine = lines[1];
+    EXPECT_EQ(dirLine[0], "dir");
+    EXPECT_EQ(dirLine[1], "destdir");
+    EXPECT_EQ(dirLine[2], "0644");
+    EXPECT_EQ(dirLine[3], "root");
+    EXPECT_EQ(dirLine[4], "root");
+    EXPECT_EQ(dirLine[5], dirHash);
+
+    EXPECT_EQ(lines[2][0], "dir/a.txt");
+    EXPECT_EQ(lines[2][1], "destdir/a.txt");
+    EXPECT_EQ(lines[2][5], hashA);
+
+    EXPECT_EQ(lines[3][0], "dir/sub/b.txt");
+    EXPECT_EQ(lines[3][1], "destdir/sub/b.txt");
+    EXPECT_EQ(lines[3][5], hashB);
+
+    remove_all(tmp);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- extend `IManifestWriter` and implementation to output tab-separated `relpath`, `dest`, `mode`, `owner`, `group`, `md5`
- expand directory entries recursively and compute virtual directory hashes
- add unit test for manifest format

## Testing
- `g++ -std=c++17 -IFirmwarePackager/third_party/googletest-1.17.0/googletest/include -IFirmwarePackager/third_party/googletest-1.17.0/googletest FirmwarePackager/third_party/googletest-1.17.0/googletest/src/gtest-all.cc FirmwarePackager/src/core/ManifestWriter.cpp FirmwarePackager/src/core/ProjectModel.cpp tests/manifest_writer_test.cpp -IFirmwarePackager/src -IFirmwarePackager -lcrypto -lpthread -o manifest_writer_test && ./manifest_writer_test`

------
https://chatgpt.com/codex/tasks/task_e_68bea7c33618832796b23447f38cfde2