### PR TITLE
Add recovery script templates and extend ScriptWriter

### DIFF
--- a/FirmwarePackager/templates/scripts/init/sysv/S95-upgrade-recover.in
+++ b/FirmwarePackager/templates/scripts/init/sysv/S95-upgrade-recover.in
@@ -1,0 +1,25 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          upgrade-recover
+# Required-Start:    $local_fs
+# Required-Stop:
+# Default-Start:     S
+# Default-Stop:
+# Short-Description: Run recovery after upgrade
+### END INIT INFO
+
+PKG_ID="@PKG_ID@"
+PKG_NAME="@PKG_NAME@"
+PKG_VERSION="@PKG_VERSION@"
+
+case "$1" in
+    start)
+        /usr/lib/${PKG_NAME}/recover_boot.sh
+        ;;
+    *)
+        echo "Usage: $0 start" >&2
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/FirmwarePackager/templates/scripts/install.sh.in
+++ b/FirmwarePackager/templates/scripts/install.sh.in
@@ -1,28 +1,61 @@
 #!/bin/sh
+
+set -e
+
 PKG_ID="@PKG_ID@"
 PKG_NAME="@PKG_NAME@"
+PKG_VERSION="@PKG_VERSION@"
 FILES="@FILES@"
 
-state="init"
+LOG_FILE="/var/log/${PKG_NAME}-install.log"
+STATE="init"
+
+log() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') [$STATE] $1" >> "$LOG_FILE"
+}
+
+rollback() {
+    log "rolling back"
+    for f in $FILES; do
+        rm -f "/$f"
+    done
+}
+
+cleanup() {
+    log "cleanup"
+}
+
+trap 'STATE=rollback; log "error"; rollback; cleanup; exit 1' INT TERM HUP QUIT
+trap 'cleanup' EXIT
+
 while true; do
-    case "$state" in
+    case "$STATE" in
         init)
-            echo "Installing $PKG_NAME ($PKG_ID)"
-            state="copy"
+            log "starting install for ${PKG_NAME}-${PKG_VERSION} (${PKG_ID})"
+            STATE="copy"
             ;;
         copy)
             for f in $FILES; do
-                echo "Processing $f"
+                log "installing $f"
+                # install step placeholder
+                :
             done
-            state="done"
+            STATE="done"
+            ;;
+        rollback)
+            rollback
+            STATE="done"
             ;;
         done)
+            log "installation complete"
             break
             ;;
         *)
-            echo "Unknown state: $state" >&2
+            log "unknown state $STATE"
             exit 1
             ;;
     esac
+
 done
+
 exit 0

--- a/FirmwarePackager/templates/scripts/recover_boot.sh.in
+++ b/FirmwarePackager/templates/scripts/recover_boot.sh.in
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+PKG_ID="@PKG_ID@"
+PKG_NAME="@PKG_NAME@"
+PKG_VERSION="@PKG_VERSION@"
+
+echo "Recovering boot for ${PKG_NAME}-${PKG_VERSION} (${PKG_ID})"
+# Placeholder for actual recovery logic
+exit 0

--- a/tests/script_writer_test.cpp
+++ b/tests/script_writer_test.cpp
@@ -1,0 +1,47 @@
+#include <gtest/gtest.h>
+#include "core/ScriptWriter.h"
+#include "core/ProjectModel.h"
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+
+using namespace std::filesystem;
+
+TEST(ScriptWriterTest, GeneratesScriptsWithReplacements){
+    core::Project project;
+    project.name = "demo";
+    project.version = "1.0";
+    core::FileEntry fe; fe.path = "file1"; project.files.push_back(fe);
+
+    path out = temp_directory_path()/"sw_out";
+    remove_all(out);
+
+    // ScriptWriter expects templates/ under current working directory
+    auto cwd = current_path();
+    current_path("FirmwarePackager");
+    core::ScriptWriter writer;
+    writer.write(project, out);
+    current_path(cwd);
+
+    EXPECT_TRUE(exists(out/"install.sh"));
+    EXPECT_TRUE(exists(out/"recover_boot.sh"));
+    EXPECT_TRUE(exists(out/"init/sysv/S95-upgrade-recover"));
+
+    std::ifstream in(out/"install.sh");
+    std::stringstream buffer; buffer << in.rdbuf();
+    std::string content = buffer.str();
+    std::string pkgId = std::to_string(std::hash<std::string>{}(project.name));
+    EXPECT_NE(content.find(project.name), std::string::npos);
+    EXPECT_NE(content.find(project.version), std::string::npos);
+    EXPECT_NE(content.find(pkgId), std::string::npos);
+    EXPECT_EQ(content.find("@PKG_NAME@"), std::string::npos);
+    EXPECT_EQ(content.find("@PKG_VERSION@"), std::string::npos);
+
+    auto perms = status(out/"install.sh").permissions();
+    EXPECT_NE(perms & perms::owner_exec, perms::none);
+}
+
+int main(int argc, char** argv){
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- add install, recover boot, and init templates for upgrade recovery
- expand ScriptWriter to process nested templates and substitute version info
- add unit test to verify generated scripts

## Testing
- `g++ -std=c++17 tests/script_writer_test.cpp FirmwarePackager/src/core/ScriptWriter.cpp FirmwarePackager/src/core/ProjectModel.cpp -I FirmwarePackager/src -I FirmwarePackager/src/core -lgtest -lgtest_main -pthread -o script_writer_test`
- `./script_writer_test`
- `g++ -std=c++17 tests/manifest_writer_test.cpp FirmwarePackager/src/core/ManifestWriter.cpp FirmwarePackager/src/core/ProjectModel.cpp -I FirmwarePackager/src -I FirmwarePackager/src/core -lgtest -lgtest_main -lcrypto -pthread -o manifest_test`
- `./manifest_test`


------
https://chatgpt.com/codex/tasks/task_e_68bea919aac88327bcedc3a1891a870e