### PR TITLE
Refactor packager to build tarball with metadata

### DIFF
--- a/FirmwarePackager/src/core/Packager.h
+++ b/FirmwarePackager/src/core/Packager.h
@@ -15,7 +15,7 @@ class IPackager {
 public:
     virtual ~IPackager() = default;
     virtual Project buildProject(const std::filesystem::path& root, const Scanner::PathList& exclusions) = 0;
-    virtual void package(const std::filesystem::path& root, const std::filesystem::path& outdir, const Scanner::PathList& exclusions) = 0;
+    virtual void package(const Project& project) = 0;
 };
 
 class Packager : public IPackager {
@@ -24,7 +24,7 @@ public:
              IScriptWriter& script, IIdGenerator& idGen, ILogger& logger);
 
     Project buildProject(const std::filesystem::path& root, const Scanner::PathList& exclusions) override;
-    void package(const std::filesystem::path& root, const std::filesystem::path& outdir, const Scanner::PathList& exclusions) override;
+    void package(const Project& project) override;
 
 private:
     Scanner& scanner;

--- a/FirmwarePackager/src/ui/MainWindow.cpp
+++ b/FirmwarePackager/src/ui/MainWindow.cpp
@@ -122,8 +122,9 @@ void MainWindow::buildPackage() {
         QMessageBox::warning(this, "Missing Paths", "Please specify both root and output directories.");
         return;
     }
+    currentProject.rootDir = rootEdit->text().toStdString();
     currentProject.outputDir = outputEdit->text().toStdString();
-    packager->package(rootEdit->text().toStdString(), outputEdit->text().toStdString(), core::Scanner::PathList{});
+    packager->package(currentProject);
 }
 
 void MainWindow::openSettings() {


### PR DESCRIPTION
## Summary
- create temporary package layout including META and payload directories
- generate pkg.info and build.info with IDs and timestamps
- produce tarball via libarchive and clean up temp directory
- update UI to call new packager API

## Testing
- `qmake tests.pro` *(fails: command not found before installing qtbase5-dev)*
- `qmake tests.pro` *(passes after installing qtbase5-dev)*
- `make` *(fails: BCrypt symbols missing while compiling Hasher.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_68beab0f65ac8327a5b1cb4371c0af8c