### PR TITLE
Add cross-platform MD5 helpers and tests

### DIFF
--- a/FirmwarePackager/src/core/Hasher.cpp
+++ b/FirmwarePackager/src/core/Hasher.cpp
@@ -1,7 +1,11 @@
 #include "Hasher.h"
 
 #include <array>
-#include <sstream>
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <vector>
 #include <openssl/md5.h>
 
 #ifdef _WIN32
@@ -26,6 +30,7 @@ std::string toHex(const std::array<uint8_t,16>& digest) {
 } // anonymous namespace
 
 std::string Hasher::md5(const std::vector<uint8_t>& data) const {
+#ifdef _WIN32
     BCRYPT_ALG_HANDLE hAlg = nullptr;
     BCRYPT_HASH_HANDLE hHash = nullptr;
     DWORD hashLen = 0, cbData = 0;
@@ -55,6 +60,35 @@ std::string Hasher::md5(const std::vector<uint8_t>& data) const {
     BCryptDestroyHash(hHash);
     BCryptCloseAlgorithmProvider(hAlg,0);
     return toHex(hash);
+#else
+    std::array<uint8_t,16> hash{};
+    MD5(data.data(), data.size(), hash.data());
+    return toHex(hash);
+#endif
+}
+
+std::string Hasher::md5File(const std::filesystem::path& path) const {
+    std::ifstream in(path, std::ios::binary);
+    if (!in.is_open()) return {};
+    std::vector<uint8_t> data(std::istreambuf_iterator<char>(in), {});
+    return md5(data);
+}
+
+std::string Hasher::md5Directory(const std::filesystem::path& path) const {
+    if (!std::filesystem::exists(path)) return {};
+    struct Item { std::filesystem::path rel; std::string hash; };
+    std::vector<Item> items;
+    for (auto& entry : std::filesystem::recursive_directory_iterator(path)) {
+        if (!entry.is_regular_file()) continue;
+        auto rel = std::filesystem::relative(entry.path(), path);
+        items.push_back({rel, md5File(entry.path())});
+    }
+    std::sort(items.begin(), items.end(), [](const Item& a, const Item& b){ return a.rel < b.rel; });
+    std::string concat;
+    concat.reserve(items.size() * 32);
+    for (const auto& it : items) concat += it.hash;
+    std::vector<uint8_t> bytes(concat.begin(), concat.end());
+    return md5(bytes);
 }
 
 } // namespace core

--- a/FirmwarePackager/src/core/Hasher.h
+++ b/FirmwarePackager/src/core/Hasher.h
@@ -3,12 +3,15 @@
 #include <string>
 #include <vector>
 #include <cstdint>
+#include <filesystem>
 
 namespace core {
 
 class Hasher {
 public:
     std::string md5(const std::vector<uint8_t>& data) const;
+    std::string md5File(const std::filesystem::path& path) const;
+    std::string md5Directory(const std::filesystem::path& path) const;
 };
 
 } // namespace core

--- a/tests/hasher_test.cpp
+++ b/tests/hasher_test.cpp
@@ -1,0 +1,69 @@
+#include <gtest/gtest.h>
+#include "core/Hasher.h"
+#include <filesystem>
+#include <fstream>
+#include <vector>
+#include <algorithm>
+#include <openssl/md5.h>
+
+using namespace std::filesystem;
+
+namespace {
+std::string toHex(const unsigned char* digest) {
+    static const char* hex = "0123456789abcdef";
+    std::string out; out.reserve(32);
+    for (int i = 0; i < MD5_DIGEST_LENGTH; ++i) {
+        unsigned char b = digest[i];
+        out.push_back(hex[b >> 4]);
+        out.push_back(hex[b & 0xF]);
+    }
+    return out;
+}
+
+std::string md5FileRef(const path& p) {
+    std::ifstream in(p, std::ios::binary); if (!in) return {};
+    MD5_CTX ctx; MD5_Init(&ctx); char buf[4096];
+    while (in) { in.read(buf, sizeof(buf)); std::streamsize s = in.gcount(); if (s > 0) MD5_Update(&ctx, buf, static_cast<size_t>(s)); }
+    unsigned char d[MD5_DIGEST_LENGTH]; MD5_Final(d, &ctx); return toHex(d);
+}
+
+std::string md5StringRef(const std::string& s) {
+    unsigned char d[MD5_DIGEST_LENGTH];
+    MD5(reinterpret_cast<const unsigned char*>(s.data()), s.size(), d);
+    return toHex(d);
+}
+}
+
+TEST(HasherTest, Md5FileMatchesReference) {
+    path tmp = temp_directory_path() / "hasher_file.txt";
+    { std::ofstream(tmp) << "hello"; }
+    core::Hasher h;
+    EXPECT_EQ(h.md5File(tmp), md5FileRef(tmp));
+    remove(tmp);
+}
+
+TEST(HasherTest, Md5DirectoryAggregatesChildren) {
+    path dir = temp_directory_path() / "hasher_dir";
+    remove_all(dir);
+    create_directories(dir / "sub");
+    { std::ofstream(dir / "a.txt") << "alpha"; }
+    { std::ofstream(dir / "sub" / "b.txt") << "beta"; }
+
+    core::Hasher h;
+    std::string hashA = md5FileRef(dir / "a.txt");
+    std::string hashB = md5FileRef(dir / "sub" / "b.txt");
+    std::vector<std::pair<path, std::string>> entries = {{"a.txt", hashA}, {"sub/b.txt", hashB}};
+    std::sort(entries.begin(), entries.end(), [](const auto& a, const auto& b){ return a.first < b.first; });
+    std::string concat;
+    for (const auto& e : entries) concat += e.second;
+    std::string expected = md5StringRef(concat);
+    EXPECT_EQ(h.md5Directory(dir), expected);
+
+    remove_all(dir);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+


### PR DESCRIPTION
## Summary
- use OpenSSL to hash data when Windows-specific BCrypt isn't available
- add `md5File` and `md5Directory` helpers on `Hasher`
- cover file and directory hashing in new tests

## Testing
- `g++ -std=c++17 tests/hasher_test.cpp FirmwarePackager/src/core/Hasher.cpp FirmwarePackager/third_party/googletest-1.17.0/googletest/src/gtest-all.cc -IFirmwarePackager/src -IFirmwarePackager -IFirmwarePackager/third_party/googletest-1.17.0/googletest/include -IFirmwarePackager/third_party/googletest-1.17.0/googletest -lcrypto -lpthread -o hasher_test && ./hasher_test`
- `g++ -std=c++17 tests/manifest_writer_test.cpp FirmwarePackager/src/core/ManifestWriter.cpp FirmwarePackager/src/core/Hasher.cpp FirmwarePackager/src/core/ProjectModel.cpp FirmwarePackager/third_party/googletest-1.17.0/googletest/src/gtest-all.cc -IFirmwarePackager/src -IFirmwarePackager -IFirmwarePackager/third_party/googletest-1.17.0/googletest/include -IFirmwarePackager/third_party/googletest-1.17.0/googletest -lcrypto -lpthread -o manifest_writer_test && ./manifest_writer_test`
- `g++ -std=c++17 tests/script_writer_test.cpp FirmwarePackager/src/core/ScriptWriter.cpp FirmwarePackager/src/core/ProjectModel.cpp FirmwarePackager/third_party/googletest-1.17.0/googletest/src/gtest-all.cc -IFirmwarePackager/src -IFirmwarePackager -IFirmwarePackager/third_party/googletest-1.17.0/googletest/include -IFirmwarePackager/third_party/googletest-1.17.0/googletest -lpthread -o script_writer_test && ./script_writer_test`


------
https://chatgpt.com/codex/tasks/task_e_68beadef6d9c832795642e1ecc37946a