### PR TITLE
Add boot recovery script and tests

### DIFF
--- a/FirmwarePackager/src/core/ScriptWriter.cpp
+++ b/FirmwarePackager/src/core/ScriptWriter.cpp
@@ -2,6 +2,7 @@
 
 #include <fstream>
 #include <sstream>
+#include <vector>
 
 namespace core {
 
@@ -33,9 +34,15 @@ void ScriptWriter::write(const Project& project, const std::filesystem::path& ou
     }
 
     std::filesystem::path tplDir = std::filesystem::path("templates") / "scripts";
-    for (const auto& entry : std::filesystem::recursive_directory_iterator(tplDir)) {
-        if (!entry.is_regular_file()) continue;
-        std::ifstream in(entry.path());
+    std::vector<std::filesystem::path> templates = {
+        tplDir / "install.sh.in",
+        tplDir / "recover_boot.sh.in",
+        tplDir / "init/sysv/S95-upgrade-recover.in"
+    };
+
+    for (const auto& tpl : templates) {
+        if (!std::filesystem::exists(tpl)) continue;
+        std::ifstream in(tpl);
         std::stringstream buffer;
         buffer << in.rdbuf();
         std::string content = buffer.str();
@@ -45,7 +52,7 @@ void ScriptWriter::write(const Project& project, const std::filesystem::path& ou
         content = replaceAll(content, "@PKG_VERSION@", pkgVersion);
         content = replaceAll(content, "@FILES@", files);
 
-        std::filesystem::path rel = std::filesystem::relative(entry.path(), tplDir);
+        std::filesystem::path rel = std::filesystem::relative(tpl, tplDir);
         std::filesystem::path outFile = outRoot / rel;
         if (outFile.extension() == ".in") {
             outFile.replace_extension("");

--- a/FirmwarePackager/templates/scripts/init/sysv/S95-upgrade-recover.in
+++ b/FirmwarePackager/templates/scripts/init/sysv/S95-upgrade-recover.in
@@ -7,14 +7,9 @@
 # Default-Stop:
 # Short-Description: Run recovery after upgrade
 ### END INIT INFO
-
-PKG_ID="@PKG_ID@"
-PKG_NAME="@PKG_NAME@"
-PKG_VERSION="@PKG_VERSION@"
-
 case "$1" in
     start)
-        /usr/lib/${PKG_NAME}/recover_boot.sh
+        /opt/upgrade/last/scripts/recover_boot.sh
         ;;
     *)
         echo "Usage: $0 start" >&2

--- a/FirmwarePackager/templates/scripts/recover_boot.sh.in
+++ b/FirmwarePackager/templates/scripts/recover_boot.sh.in
@@ -13,8 +13,10 @@ for st in "$STATE_DIR"/*.state; do
     [ -f "$ARCHIVE" ] || continue
     TMP="$(mktemp -d)"
     tar -xzf "$ARCHIVE" -C "$TMP"
-    if [ -f "$TMP/install.sh" ]; then
-        (cd "$TMP" && ./install.sh --resume)
+    if [ -f "$TMP/package/scripts/install.sh" ]; then
+        (
+            cd "$TMP/package" && ./scripts/install.sh --resume
+        )
     fi
     rm -rf "$TMP"
 done

--- a/tests/recover_boot_script_test.cpp
+++ b/tests/recover_boot_script_test.cpp
@@ -1,0 +1,63 @@
+#include <gtest/gtest.h>
+#include <filesystem>
+#include <fstream>
+#include <cstdlib>
+
+using namespace std::filesystem;
+
+TEST(RecoverBootScript, RunsInstallWithResumeAndKeepsState) {
+    path stateDir = "/opt/upgrade/state";
+    path pkgDir = "/opt/upgrade/packages";
+    remove_all(stateDir);
+    remove_all(pkgDir);
+    create_directories(stateDir);
+    create_directories(pkgDir);
+
+    std::string id = "testpkg";
+    path stateFile = stateDir / (id + ".state");
+    { std::ofstream(stateFile) << "STATUS=RUNNING\n"; }
+
+    path temp = temp_directory_path() / "recover_pkg";
+    remove_all(temp);
+    create_directories(temp / "package/scripts");
+
+    path install = temp / "package/scripts/install.sh";
+    {
+        std::ofstream out(install);
+        out << "#!/bin/sh\n";
+        out << "echo \"$1\" > /tmp/install_arg\n";
+    }
+    permissions(install, perms::owner_read | perms::owner_write | perms::owner_exec);
+
+    path archive = pkgDir / (id + ".tar.gz");
+    std::string cmd = "tar -czf " + archive.string() + " -C " + temp.string() + " package";
+    ASSERT_EQ(std::system(cmd.c_str()), 0);
+
+    path script = temp_directory_path() / "recover_boot.sh";
+    {
+        std::ifstream in("FirmwarePackager/templates/scripts/recover_boot.sh.in");
+        std::ofstream out(script);
+        out << in.rdbuf();
+    }
+    permissions(script, perms::owner_read | perms::owner_write | perms::owner_exec);
+
+    ASSERT_EQ(std::system(script.string().c_str()), 0);
+
+    std::ifstream arg("/tmp/install_arg");
+    std::string argVal;
+    std::getline(arg, argVal);
+    EXPECT_EQ(argVal, "--resume");
+
+    EXPECT_TRUE(exists(stateFile));
+
+    remove("/tmp/install_arg");
+    remove_all(temp);
+    remove_all(pkgDir);
+    remove_all(stateDir);
+}
+
+int main(int argc, char** argv){
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+


### PR DESCRIPTION
## Summary
- recover unfinished upgrades by extracting packages and calling their install scripts with `--resume`
- provide SysV init script to run boot recovery
- ensure ScriptWriter emits recovery and init scripts
- test recovery script behavior

## Testing
- `g++ -std=c++17 tests/script_writer_test.cpp FirmwarePackager/src/core/ScriptWriter.cpp FirmwarePackager/src/core/ProjectModel.cpp -I FirmwarePackager -I FirmwarePackager/src -lgtest -lgtest_main -pthread -o /tmp/script_writer_test`
- `/tmp/script_writer_test`
- `g++ -std=c++17 tests/recover_boot_script_test.cpp -lgtest -lgtest_main -pthread -o /tmp/recover_boot_script_test`
- `/tmp/recover_boot_script_test`
- `g++ -std=c++17 tests/install_script_test.cpp -I FirmwarePackager -I FirmwarePackager/src -lcrypto -lgtest -lgtest_main -pthread -o /tmp/install_script_test`
- `/tmp/install_script_test`
- `g++ -std=c++17 tests/packager_test.cpp FirmwarePackager/src/core/Hasher.cpp FirmwarePackager/src/core/IdGenerator.cpp FirmwarePackager/src/core/Logger.cpp FirmwarePackager/src/core/ManifestWriter.cpp FirmwarePackager/src/core/Packager.cpp FirmwarePackager/src/core/ProjectModel.cpp FirmwarePackager/src/core/ProjectSerializer.cpp FirmwarePackager/src/core/Scanner.cpp FirmwarePackager/src/core/ScriptWriter.cpp -I FirmwarePackager -I FirmwarePackager/src -larchive -lcrypto -lgtest -lgtest_main -pthread -o /tmp/packager_test`
- `/tmp/packager_test`


------
https://chatgpt.com/codex/tasks/task_e_68bebab86e108327ad2202a674a493f1