### PR TITLE
Refactor ScriptWriter to use IdGenerator and simplify templates

### DIFF
--- a/FirmwarePackager/src/core/ScriptWriter.h
+++ b/FirmwarePackager/src/core/ScriptWriter.h
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include "ProjectModel.h"
+#include "IdGenerator.h"
 
 namespace core {
 
@@ -13,7 +14,11 @@ public:
 
 class ScriptWriter : public IScriptWriter {
 public:
+    explicit ScriptWriter(IIdGenerator& idGen);
     void write(const Project& project, const std::filesystem::path& output) const override;
+
+private:
+    IIdGenerator& idGen;
 };
 
 } // namespace core

--- a/FirmwarePackager/src/ui/MainWindow.cpp
+++ b/FirmwarePackager/src/ui/MainWindow.cpp
@@ -23,7 +23,7 @@
 #include <filesystem>
 
 MainWindow::MainWindow(QWidget* parent)
-    : QMainWindow(parent), guiLogger(nullptr) {
+    : QMainWindow(parent), guiLogger(nullptr), idGen(), script(idGen) {
     setWindowTitle("Upgrade Builder");
 
     // file menu

--- a/FirmwarePackager/src/ui/MainWindow.h
+++ b/FirmwarePackager/src/ui/MainWindow.h
@@ -42,8 +42,8 @@ private:
     core::Scanner scanner;
     core::Hasher hasher;
     core::ManifestWriter manifest;
-    core::ScriptWriter script;
     core::IdGenerator idGen;
+    core::ScriptWriter script;
     core::ProjectSerializer serializer;
     std::unique_ptr<core::Packager> packager;
     core::Project currentProject;

--- a/tests/packager_test.cpp
+++ b/tests/packager_test.cpp
@@ -31,8 +31,8 @@ TEST(PackagerTest, GeneratesArchiveWithExpectedContents) {
     core::Scanner scanner;
     core::Hasher hasher;
     core::ManifestWriter mw;
-    core::ScriptWriter sw;
     core::IdGenerator idgen;
+    core::ScriptWriter sw(idgen);
     SilentLogger logger;
     core::Packager pack(scanner, hasher, mw, sw, idgen, logger);
 

--- a/tests/script_writer_test.cpp
+++ b/tests/script_writer_test.cpp
@@ -19,7 +19,8 @@ TEST(ScriptWriterTest, GeneratesScriptsWithReplacements){
     // ScriptWriter expects templates/ under current working directory
     auto cwd = current_path();
     current_path("FirmwarePackager");
-    core::ScriptWriter writer;
+    core::IdGenerator idGen;
+    core::ScriptWriter writer(idGen);
     writer.write(project, out);
     current_path(cwd);
 
@@ -30,12 +31,14 @@ TEST(ScriptWriterTest, GeneratesScriptsWithReplacements){
     std::ifstream in(out/"scripts/install.sh");
     std::stringstream buffer; buffer << in.rdbuf();
     std::string content = buffer.str();
-    std::string pkgId = std::to_string(std::hash<std::string>{}(project.name));
+    core::IdGenerator tmpGen;
+    std::string pkgId = tmpGen.generate();
     EXPECT_NE(content.find(project.name), std::string::npos);
     EXPECT_NE(content.find(project.version), std::string::npos);
     EXPECT_NE(content.find(pkgId), std::string::npos);
     EXPECT_EQ(content.find("@PKG_NAME@"), std::string::npos);
     EXPECT_EQ(content.find("@PKG_VERSION@"), std::string::npos);
+    EXPECT_EQ(content.find("@FILES@"), std::string::npos);
 
     auto perms = status(out/"scripts/install.sh").permissions();
     EXPECT_NE(perms & perms::owner_exec, perms::none);


### PR DESCRIPTION
## Summary
- Generate package IDs via `IdGenerator` and drop `@FILES@` placeholder in script templates
- Copy all templates under `templates/scripts/` to the package while replacing only `@PKG_ID@`, `@PKG_NAME@`, and `@PKG_VERSION@`
- Update tests for new ID generation and placeholder removal

## Testing
- `./build/script_writer_test`
- `./build/packager_test`


------
https://chatgpt.com/codex/tasks/task_e_68bebd002ffc8327b0ea506e597d5842