### PR TITLE
Use timestamp-based ID generation

### DIFF
--- a/FirmwarePackager/src/core/IdGenerator.cpp
+++ b/FirmwarePackager/src/core/IdGenerator.cpp
@@ -1,16 +1,36 @@
 #include "IdGenerator.h"
 
-#include <sstream>
+#include <chrono>
+#include <ctime>
 #include <iomanip>
+#include <sstream>
 
 namespace core {
 
-IdGenerator::IdGenerator() : counter(0) {}
+IdGenerator::IdGenerator() : rng(std::random_device{}()), dist(0, 0xFFFFFFFF) {}
 
 std::string IdGenerator::generate() {
-    uint64_t value = counter.fetch_add(1, std::memory_order_relaxed);
+    using namespace std::chrono;
+    auto now = system_clock::now();
+    std::time_t t = system_clock::to_time_t(now);
+    std::tm tm;
+#ifdef _WIN32
+    gmtime_s(&tm, &t);
+#else
+    gmtime_r(&t, &tm);
+#endif
+
+    char buf[16];
+    std::strftime(buf, sizeof(buf), "%Y%m%d-%H%M%S", &tm);
+
+    uint32_t r;
+    {
+        std::lock_guard<std::mutex> lock(mtx);
+        r = dist(rng);
+    }
+
     std::ostringstream oss;
-    oss << std::hex << std::setw(16) << std::setfill('0') << value;
+    oss << buf << '-' << std::hex << std::setw(8) << std::setfill('0') << r;
     return oss.str();
 }
 

--- a/FirmwarePackager/src/core/IdGenerator.h
+++ b/FirmwarePackager/src/core/IdGenerator.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <atomic>
 #include <string>
+#include <random>
+#include <mutex>
 
 namespace core {
 
@@ -16,7 +17,9 @@ public:
     IdGenerator();
     std::string generate() override;
 private:
-    std::atomic<uint64_t> counter;
+    std::mt19937 rng;
+    std::mutex mtx;
+    std::uniform_int_distribution<uint32_t> dist;
 };
 
 } // namespace core

--- a/FirmwarePackager/src/core/Packager.cpp
+++ b/FirmwarePackager/src/core/Packager.cpp
@@ -35,7 +35,8 @@ Project Packager::buildProject(const std::filesystem::path& root, const Scanner:
 
 void Packager::package(const Project& project) {
     logger.info("Packaging project");
-    auto tempRoot = std::filesystem::temp_directory_path() / ("package-" + idGen.generate());
+    std::string pkgId = idGen.generate();
+    auto tempRoot = std::filesystem::temp_directory_path() / ("package-" + pkgId);
     std::filesystem::create_directories(tempRoot);
 
     std::filesystem::path packageDir = tempRoot / "package";
@@ -81,7 +82,6 @@ void Packager::package(const Project& project) {
 
     auto now = std::chrono::system_clock::now();
     std::time_t t = std::chrono::system_clock::to_time_t(now);
-    std::string pkgId = idGen.generate();
 
     std::ofstream pkgInfo(metaDir / "pkg.info");
     pkgInfo << "PKG_ID=" << pkgId << "\n";

--- a/tests/id_generator_test.cpp
+++ b/tests/id_generator_test.cpp
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+#include "core/IdGenerator.h"
+
+#include <regex>
+#include <thread>
+#include <unordered_set>
+#include <mutex>
+
+TEST(IdGeneratorTest, GeneratesExpectedFormat) {
+    core::IdGenerator gen;
+    std::string id = gen.generate();
+    std::regex pattern(R"(\d{8}-\d{6}-[0-9a-f]{8})");
+    EXPECT_TRUE(std::regex_match(id, pattern));
+}
+
+TEST(IdGeneratorTest, ProducesUniqueIds) {
+    core::IdGenerator gen;
+    std::unordered_set<std::string> ids;
+    std::mutex m;
+    std::vector<std::thread> threads;
+    for (int t = 0; t < 4; ++t) {
+        threads.emplace_back([&]() {
+            for (int i = 0; i < 50; ++i) {
+                auto id = gen.generate();
+                std::lock_guard<std::mutex> lock(m);
+                ids.insert(std::move(id));
+            }
+        });
+    }
+    for (auto& th : threads) th.join();
+    EXPECT_EQ(ids.size(), 200u);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+


### PR DESCRIPTION
## Summary
- combine UTC timestamps with random hex to generate unique IDs
- use generated package ID consistently when writing META/pkg.info
- add unit tests covering format and uniqueness of IDs

## Testing
- `g++ -std=c++17 tests/id_generator_test.cpp FirmwarePackager/src/core/IdGenerator.cpp FirmwarePackager/third_party/googletest-1.17.0/googletest/src/gtest-all.cc -I FirmwarePackager/src -I FirmwarePackager -I FirmwarePackager/third_party/googletest-1.17.0/googletest/include -I FirmwarePackager/third_party/googletest-1.17.0/googletest -pthread -o idgen_test && ./idgen_test`
- `g++ -std=c++17 tests/packager_test.cpp FirmwarePackager/src/core/Packager.cpp FirmwarePackager/src/core/Scanner.cpp FirmwarePackager/src/core/Hasher.cpp FirmwarePackager/src/core/ManifestWriter.cpp FirmwarePackager/src/core/ScriptWriter.cpp FirmwarePackager/src/core/ProjectModel.cpp FirmwarePackager/src/core/IdGenerator.cpp FirmwarePackager/src/core/Logger.cpp FirmwarePackager/third_party/googletest-1.17.0/googletest/src/gtest-all.cc -I FirmwarePackager/src -I FirmwarePackager -I FirmwarePackager/third_party/googletest-1.17.0/googletest/include -I FirmwarePackager/third_party/googletest-1.17.0/googletest -pthread -larchive -lcrypto -o packager_test && ./packager_test`


------
https://chatgpt.com/codex/tasks/task_e_68bec40a0e4c8327899a6f1b08ceea2c