### PR TITLE
Pass package ID from Packager to ScriptWriter

### DIFF
--- a/FirmwarePackager/src/core/Packager.cpp
+++ b/FirmwarePackager/src/core/Packager.cpp
@@ -78,7 +78,7 @@ void Packager::package(const Project& project) {
     }
 
     manifest.write(project, packageDir / "manifest.tsv");
-    script.write(project, packageDir);
+    script.write(project, packageDir, pkgId);
 
     auto now = std::chrono::system_clock::now();
     std::time_t t = std::chrono::system_clock::to_time_t(now);

--- a/FirmwarePackager/src/core/ScriptWriter.cpp
+++ b/FirmwarePackager/src/core/ScriptWriter.cpp
@@ -16,16 +16,14 @@ std::string replaceAll(std::string str, const std::string& from, const std::stri
 }
 }
 
-ScriptWriter::ScriptWriter(IIdGenerator& gen) : idGen(gen) {}
-
-void ScriptWriter::write(const Project& project, const std::filesystem::path& output) const {
+void ScriptWriter::write(const Project& project, const std::filesystem::path& output,
+                         const std::string& pkgId) const {
     // scripts are always emitted into a "scripts" subdirectory of the output
     std::filesystem::path outRoot = output / "scripts";
     std::filesystem::create_directories(outRoot);
 
     // Build replacement values
     std::string pkgName = project.name;
-    std::string pkgId = idGen.generate();
     std::string pkgVersion = project.version;
 
     std::filesystem::path tplDir = std::filesystem::path("templates") / "scripts";

--- a/FirmwarePackager/src/core/ScriptWriter.h
+++ b/FirmwarePackager/src/core/ScriptWriter.h
@@ -1,24 +1,23 @@
 #pragma once
 
 #include <filesystem>
+#include <string>
 #include "ProjectModel.h"
-#include "IdGenerator.h"
 
 namespace core {
 
 class IScriptWriter {
 public:
     virtual ~IScriptWriter() = default;
-    virtual void write(const Project& project, const std::filesystem::path& output) const = 0;
+    virtual void write(const Project& project, const std::filesystem::path& output,
+                      const std::string& pkgId) const = 0;
 };
 
 class ScriptWriter : public IScriptWriter {
 public:
-    explicit ScriptWriter(IIdGenerator& idGen);
-    void write(const Project& project, const std::filesystem::path& output) const override;
-
-private:
-    IIdGenerator& idGen;
+    ScriptWriter() = default;
+    void write(const Project& project, const std::filesystem::path& output,
+               const std::string& pkgId) const override;
 };
 
 } // namespace core

--- a/FirmwarePackager/src/ui/MainWindow.cpp
+++ b/FirmwarePackager/src/ui/MainWindow.cpp
@@ -23,7 +23,7 @@
 #include <filesystem>
 
 MainWindow::MainWindow(QWidget* parent)
-    : QMainWindow(parent), guiLogger(nullptr), idGen(), script(idGen) {
+    : QMainWindow(parent), guiLogger(nullptr) {
     setWindowTitle("Upgrade Builder");
 
     // file menu
@@ -320,7 +320,7 @@ void MainWindow::previewScript() {
         return;
     }
     try {
-        script.write(currentProject, tempDir.path().toStdString());
+        script.write(currentProject, tempDir.path().toStdString(), idGen.generate());
     } catch (const std::exception& e) {
         QMessageBox::critical(this, "Error", e.what());
         return;

--- a/tests/packager_test.cpp
+++ b/tests/packager_test.cpp
@@ -10,6 +10,7 @@
 #include <fstream>
 #include <sstream>
 #include <cstdlib>
+#include <string>
 
 using namespace std::filesystem;
 
@@ -34,7 +35,7 @@ TEST(PackagerTest, GeneratesArchiveWithExpectedContents) {
     core::Hasher hasher;
     core::ManifestWriter mw;
     core::IdGenerator idgen;
-    core::ScriptWriter sw(idgen);
+    core::ScriptWriter sw;
     SilentLogger logger;
     core::Packager pack(scanner, hasher, mw, sw, idgen, logger);
 
@@ -45,7 +46,7 @@ TEST(PackagerTest, GeneratesArchiveWithExpectedContents) {
     core::FileEntry fe; fe.path="dir"; fe.dest="destdir"; fe.recursive=true; fe.excludes={"sub","exclude.txt"}; project.files.push_back(fe);
 
     auto cwd = current_path();
-    current_path("FirmwarePackager");
+    current_path("FirmwarePackager/FirmwarePackager");
     pack.package(project);
     current_path(cwd);
 

--- a/tests/script_writer_test.cpp
+++ b/tests/script_writer_test.cpp
@@ -1,9 +1,11 @@
 #include <gtest/gtest.h>
 #include "core/ScriptWriter.h"
 #include "core/ProjectModel.h"
+#include "core/IdGenerator.h"
 #include <filesystem>
 #include <fstream>
 #include <sstream>
+#include <string>
 
 using namespace std::filesystem;
 
@@ -18,10 +20,11 @@ TEST(ScriptWriterTest, GeneratesScriptsWithReplacements){
 
     // ScriptWriter expects templates/ under current working directory
     auto cwd = current_path();
-    current_path("FirmwarePackager");
+    current_path("FirmwarePackager/FirmwarePackager");
     core::IdGenerator idGen;
-    core::ScriptWriter writer(idGen);
-    writer.write(project, out);
+    core::ScriptWriter writer;
+    std::string pkgId = idGen.generate();
+    writer.write(project, out, pkgId);
     current_path(cwd);
 
     EXPECT_TRUE(exists(out/"scripts/install.sh"));
@@ -31,8 +34,6 @@ TEST(ScriptWriterTest, GeneratesScriptsWithReplacements){
     std::ifstream in(out/"scripts/install.sh");
     std::stringstream buffer; buffer << in.rdbuf();
     std::string content = buffer.str();
-    core::IdGenerator tmpGen;
-    std::string pkgId = tmpGen.generate();
     EXPECT_NE(content.find(project.name), std::string::npos);
     EXPECT_NE(content.find(project.version), std::string::npos);
     EXPECT_NE(content.find(pkgId), std::string::npos);


### PR DESCRIPTION
## Summary
- Generate package ID once in Packager and pass to ScriptWriter
- ScriptWriter now accepts an external package ID instead of generating its own
- Update UI and tests to use shared package ID

## Testing
- `g++ -std=c++17 FirmwarePackager/tests/script_writer_test.cpp FirmwarePackager/FirmwarePackager/src/core/ScriptWriter.cpp FirmwarePackager/FirmwarePackager/src/core/ProjectModel.cpp FirmwarePackager/FirmwarePackager/src/core/IdGenerator.cpp FirmwarePackager/FirmwarePackager/third_party/googletest-1.17.0/googletest/src/gtest-all.cc -IFirmwarePackager/FirmwarePackager/src -IFirmwarePackager/FirmwarePackager -IFirmwarePackager/FirmwarePackager/third_party/googletest-1.17.0/googletest/include -IFirmwarePackager/FirmwarePackager/third_party/googletest-1.17.0/googletest -pthread -o script_writer_test && ./script_writer_test` 
- `g++ -std=c++17 FirmwarePackager/tests/packager_test.cpp FirmwarePackager/FirmwarePackager/src/core/Packager.cpp FirmwarePackager/FirmwarePackager/src/core/ProjectModel.cpp FirmwarePackager/FirmwarePackager/src/core/Scanner.cpp FirmwarePackager/FirmwarePackager/src/core/Hasher.cpp FirmwarePackager/FirmwarePackager/src/core/ManifestWriter.cpp FirmwarePackager/FirmwarePackager/src/core/ScriptWriter.cpp FirmwarePackager/FirmwarePackager/src/core/IdGenerator.cpp FirmwarePackager/FirmwarePackager/src/core/Logger.cpp FirmwarePackager/FirmwarePackager/third_party/googletest-1.17.0/googletest/src/gtest-all.cc -IFirmwarePackager/FirmwarePackager/src -IFirmwarePackager/FirmwarePackager -IFirmwarePackager/FirmwarePackager/third_party/googletest-1.17.0/googletest/include -IFirmwarePackager/FirmwarePackager/third_party/googletest-1.17.0/googletest -pthread -larchive -lcrypto -o packager_test && ./packager_test`
- `g++ -std=c++17 FirmwarePackager/tests/id_generator_test.cpp FirmwarePackager/FirmwarePackager/src/core/IdGenerator.cpp FirmwarePackager/FirmwarePackager/third_party/googletest-1.17.0/googletest/src/gtest-all.cc -IFirmwarePackager/FirmwarePackager/src -IFirmwarePackager/FirmwarePackager -IFirmwarePackager/FirmwarePackager/third_party/googletest-1.17.0/googletest/include -IFirmwarePackager/FirmwarePackager/third_party/googletest-1.17.0/googletest -pthread -o id_generator_test && ./id_generator_test`
- `g++ -std=c++17 FirmwarePackager/tests/hasher_test.cpp FirmwarePackager/FirmwarePackager/src/core/Hasher.cpp FirmwarePackager/FirmwarePackager/src/core/ProjectModel.cpp FirmwarePackager/FirmwarePackager/src/core/IdGenerator.cpp FirmwarePackager/FirmwarePackager/third_party/googletest-1.17.0/googletest/src/gtest-all.cc -IFirmwarePackager/FirmwarePackager/src -IFirmwarePackager/FirmwarePackager -IFirmwarePackager/FirmwarePackager/third_party/googletest-1.17.0/googletest/include -IFirmwarePackager/FirmwarePackager/third_party/googletest-1.17.0/googletest -pthread -lcrypto -o hasher_test && ./hasher_test`

------
https://chatgpt.com/codex/tasks/task_e_68bec859c818832786401c92d887e45f