### PR TITLE
Remove directory entries from manifest output

### DIFF
--- a/FirmwarePackager/src/core/ManifestWriter.cpp
+++ b/FirmwarePackager/src/core/ManifestWriter.cpp
@@ -79,16 +79,6 @@ void ManifestWriter::write(const Project& project, const std::filesystem::path& 
                 }
             }
             std::sort(files.begin(), files.end(), [](const Rec& a, const Rec& b){ return a.rel < b.rel; });
-            std::string concat;
-            concat.reserve(files.size() * 32);
-            for (const auto& r : files) concat += r.hash;
-            std::string dirHash = md5String(concat);
-            out << f.path.generic_string() << '\t'
-                << f.dest.generic_string() << '\t'
-                << f.mode << '\t'
-                << f.owner << '\t'
-                << f.group << '\t'
-                << dirHash << '\n';
             for (const auto& r : files) {
                 out << r.rel.generic_string() << '\t'
                     << r.dest.generic_string() << '\t'

--- a/FirmwarePackager/templates/scripts/install.sh.in
+++ b/FirmwarePackager/templates/scripts/install.sh.in
@@ -76,6 +76,9 @@ write_state
 {
     read -r _header
     while IFS="$(printf '\t')" read -r rel dest mode owner group md5; do
+        if [ -z "$rel" ] || [ "${rel#\#}" != "$rel" ]; then
+            continue
+        fi
         LAST_FILE="$dest"
         write_state
 

--- a/tests/manifest_writer_test.cpp
+++ b/tests/manifest_writer_test.cpp
@@ -21,7 +21,6 @@ std::string md5File(const path& p){
     while(in){ in.read(buf,sizeof(buf)); std::streamsize s=in.gcount(); if(s>0) MD5_Update(&ctx,buf,static_cast<size_t>(s)); }
     unsigned char d[MD5_DIGEST_LENGTH]; MD5_Final(d,&ctx); return toHex(d);
 }
-std::string md5String(const std::string& s){ unsigned char d[MD5_DIGEST_LENGTH]; MD5((const unsigned char*)s.data(), s.size(), d); return toHex(d);} 
 }
 
 TEST(ManifestWriterTest, ExpandsDirectoriesAndWritesColumns){
@@ -45,23 +44,14 @@ TEST(ManifestWriterTest, ExpandsDirectoriesAndWritesColumns){
     while(std::getline(in,line)){
         std::vector<std::string> cols; std::stringstream ss(line); std::string c; while(std::getline(ss,c,'\t')) cols.push_back(c); lines.push_back(cols); }
 
-    ASSERT_EQ(lines.size(), 3u);
+    ASSERT_EQ(lines.size(), 2u);
     EXPECT_EQ(lines[0], (std::vector<std::string>{"relpath","dest","mode","owner","group","md5"}));
 
     std::string hashA = md5File(tmp/"dir"/"a.txt");
-    std::string dirHash = md5String(hashA);
 
-    auto dirLine = lines[1];
-    EXPECT_EQ(dirLine[0], "dir");
-    EXPECT_EQ(dirLine[1], "destdir");
-    EXPECT_EQ(dirLine[2], "0644");
-    EXPECT_EQ(dirLine[3], "root");
-    EXPECT_EQ(dirLine[4], "root");
-    EXPECT_EQ(dirLine[5], dirHash);
-
-    EXPECT_EQ(lines[2][0], "dir/a.txt");
-    EXPECT_EQ(lines[2][1], "destdir/a.txt");
-    EXPECT_EQ(lines[2][5], hashA);
+    EXPECT_EQ(lines[1][0], "dir/a.txt");
+    EXPECT_EQ(lines[1][1], "destdir/a.txt");
+    EXPECT_EQ(lines[1][5], hashA);
 
     for (const auto& l : lines) {
         EXPECT_EQ(std::find(l.begin(), l.end(), "destdir/sub/b.txt"), l.end());


### PR DESCRIPTION
## Summary
- Stop emitting synthetic directory entries from ManifestWriter; now only actual files are listed.
- Update manifest_writer_test to expect just the header and file entry.
- Improve install.sh template to skip empty or comment lines when processing the manifest.

## Testing
- `g++ -std=c++17 tests/manifest_writer_test.cpp FirmwarePackager/src/core/ManifestWriter.cpp FirmwarePackager/src/core/ProjectModel.cpp -I FirmwarePackager/src -I FirmwarePackager -I tests -lgtest -lgtest_main -lcrypto -lpthread -o manifest_writer_test`
- `./manifest_writer_test`
- `g++ -std=c++17 tests/install_script_test.cpp -I FirmwarePackager/src -I FirmwarePackager -I tests -lgtest -lgtest_main -lcrypto -lpthread -o install_script_test`
- `./install_script_test`


------
https://chatgpt.com/codex/tasks/task_e_68beca3611608327840b676f0c1f9f7d