### PR TITLE
Add resume-aware install scripts with state tracking

### DIFF
--- a/FirmwarePackager/templates/scripts/install.sh.in
+++ b/FirmwarePackager/templates/scripts/install.sh.in
@@ -15,11 +15,30 @@ PKG_DIR="/opt/upgrade/packages"
 BACKUP_DIR="/opt/upgrade/backup/${PKG_ID}"
 STATE_FILE="${STATE_DIR}/${PKG_ID}.state"
 JOURNAL="${STATE_DIR}/${PKG_ID}.journal"
-PKG_TGZ="${PKG_DIR}/${PKG_ID}.tgz"
+PKG_TGZ="${PKG_DIR}/${PKG_ID}.tar.gz"
 
 STATUS="INIT"
 STEP=""
 LAST_FILE=""
+STORE=""
+RESUME=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --resume)
+            RESUME=1
+            ;;
+        --store)
+            STORE="$2"
+            shift
+            ;;
+        *)
+            echo "Usage: $0 [--resume] [--store <archive>]" >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
 
 write_state() {
 cat >"$STATE_FILE" <<STATE
@@ -44,7 +63,8 @@ rollback() {
 
 fail() {
     trap - EXIT
-    STATUS="ERROR"
+    STATUS="FAIL"
+    STEP="rollback"
     write_state
     rollback
     exit 1
@@ -58,53 +78,73 @@ cleanup_success() {
     fi
     rm -f "$JOURNAL"
     rm -rf "$BACKUP_DIR"
-    rm -f "$PKG_TGZ"
 }
 
 trap fail INT TERM HUP QUIT
 trap fail EXIT
 
 mkdir -p "$STATE_DIR" "$PKG_DIR" "$BACKUP_DIR"
-: > "$JOURNAL"
+
+if [ "$RESUME" -eq 1 ]; then
+    [ -f "$STATE_FILE" ] || exit 1
+    . "$STATE_FILE"
+    [ -f "$JOURNAL" ] || : > "$JOURNAL"
+else
+    : > "$JOURNAL"
+    STATUS="RUNNING"
+    STEP="store"
+    write_state
+    if [ -n "$STORE" ]; then
+        cp "$STORE" "$PKG_TGZ"
+    fi
+    STEP="install"
+    write_state
+fi
 
 BASE_DIR=$(cd "$(dirname "$0")/.." && pwd)
 
-STATUS="RUNNING"
-STEP="install"
-write_state
+if [ "$STEP" = "install" ]; then
+    SKIP=0
+    if [ "$RESUME" -eq 1 ] && [ -n "$LAST_FILE" ]; then
+        SKIP=1
+    fi
+    {
+        read -r _header
+        while IFS="$(printf '\t')" read -r rel dest mode owner group md5; do
+            if [ -z "$rel" ] || [ "${rel#\#}" != "$rel" ]; then
+                continue
+            fi
+            if [ "$SKIP" -eq 1 ]; then
+                [ "$dest" = "$LAST_FILE" ] && SKIP=0
+                continue
+            fi
+            LAST_FILE="$dest"
+            write_state
 
-{
-    read -r _header
-    while IFS="$(printf '\t')" read -r rel dest mode owner group md5; do
-        if [ -z "$rel" ] || [ "${rel#\#}" != "$rel" ]; then
-            continue
-        fi
-        LAST_FILE="$dest"
-        write_state
+            calc=$(md5sum "$BASE_DIR/$rel" | awk '{print $1}')
+            [ "$calc" = "$md5" ] || fail
 
-        calc=$(md5sum "$BASE_DIR/$rel" | awk '{print $1}')
-        [ "$calc" = "$md5" ] || fail
+            ddir=$(dirname "$dest")
+            mkdir -p "$ddir"
 
-        ddir=$(dirname "$dest")
-        mkdir -p "$ddir"
+            if [ -f "$dest" ]; then
+                backup="$BACKUP_DIR/$dest"
+                mkdir -p "$(dirname "$backup")"
+                cp "$dest" "$backup"
+                mv "$dest" "$dest.old"
+            fi
 
-        if [ -f "$dest" ]; then
-            backup="$BACKUP_DIR/$dest"
-            mkdir -p "$(dirname "$backup")"
-            cp "$dest" "$backup"
-            mv "$dest" "$dest.old"
-        fi
+            cp "$BASE_DIR/$rel" "$dest.new"
+            chmod "$mode" "$dest.new" 2>/dev/null || true
+            mv "$dest.new" "$dest"
+            echo "$dest" >> "$JOURNAL"
 
-        cp "$BASE_DIR/$rel" "$dest.new"
-        chmod "$mode" "$dest.new" 2>/dev/null || true
-        mv "$dest.new" "$dest"
-        echo "$dest" >> "$JOURNAL"
-
-    done
-} < "$BASE_DIR/manifest.tsv"
+        done
+    } < "$BASE_DIR/manifest.tsv"
+fi
 
 trap - EXIT
-STATUS="DONE"
+STATUS="SUCCESS"
 STEP="done"
 LAST_FILE=""
 write_state

--- a/FirmwarePackager/templates/scripts/recover_boot.sh.in
+++ b/FirmwarePackager/templates/scripts/recover_boot.sh.in
@@ -8,6 +8,10 @@ PKG_DIR="/opt/upgrade/packages"
 
 for st in "$STATE_DIR"/*.state; do
     [ -e "$st" ] || continue
+    status=$(grep '^STATUS=' "$st" | cut -d= -f2)
+    if [ "$status" = "SUCCESS" ] || [ "$status" = "FAIL" ]; then
+        continue
+    fi
     ID=$(basename "$st" .state)
     ARCHIVE="$PKG_DIR/${ID}.tar.gz"
     [ -f "$ARCHIVE" ] || continue

--- a/tests/recover_boot_script_test.cpp
+++ b/tests/recover_boot_script_test.cpp
@@ -56,6 +56,52 @@ TEST(RecoverBootScript, RunsInstallWithResumeAndKeepsState) {
     remove_all(stateDir);
 }
 
+TEST(RecoverBootScript, SkipsFinishedInstallations) {
+    path stateDir = "/opt/upgrade/state";
+    path pkgDir = "/opt/upgrade/packages";
+    remove_all(stateDir);
+    remove_all(pkgDir);
+    create_directories(stateDir);
+    create_directories(pkgDir);
+
+    std::string id = "testpkg";
+    path stateFile = stateDir / (id + ".state");
+    { std::ofstream(stateFile) << "STATUS=SUCCESS\n"; }
+
+    path temp = temp_directory_path() / "recover_pkg";
+    remove_all(temp);
+    create_directories(temp / "package/scripts");
+
+    path install = temp / "package/scripts/install.sh";
+    {
+        std::ofstream out(install);
+        out << "#!/bin/sh\n";
+        out << "echo \"called\" > /tmp/install_called\n";
+    }
+    permissions(install, perms::owner_read | perms::owner_write | perms::owner_exec);
+
+    path archive = pkgDir / (id + ".tar.gz");
+    std::string cmd = "tar -czf " + archive.string() + " -C " + temp.string() + " package";
+    ASSERT_EQ(std::system(cmd.c_str()), 0);
+
+    path script = temp_directory_path() / "recover_boot.sh";
+    {
+        std::ifstream in("FirmwarePackager/templates/scripts/recover_boot.sh.in");
+        std::ofstream out(script);
+        out << in.rdbuf();
+    }
+    permissions(script, perms::owner_read | perms::owner_write | perms::owner_exec);
+
+    ASSERT_EQ(std::system(script.string().c_str()), 0);
+
+    EXPECT_FALSE(exists("/tmp/install_called"));
+    remove("/tmp/install_called");
+
+    remove_all(temp);
+    remove_all(pkgDir);
+    remove_all(stateDir);
+}
+
 int main(int argc, char** argv){
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
## Summary
- handle `--resume` and `--store` flags in installer before doing any work
- persist package archive and state fields for resume capability
- only resume unfinished installs if state STATUS is neither SUCCESS nor FAIL

## Testing
- `g++ -std=c++17 tests/install_script_test.cpp FirmwarePackager/third_party/googletest-1.17.0/googletest/src/gtest-all.cc -I FirmwarePackager/third_party/googletest-1.17.0/googletest -I FirmwarePackager/third_party/googletest-1.17.0/googletest/include -pthread -lcrypto -o /tmp/install_script_test && /tmp/install_script_test`
- `g++ -std=c++17 tests/recover_boot_script_test.cpp FirmwarePackager/third_party/googletest-1.17.0/googletest/src/gtest-all.cc -I FirmwarePackager/third_party/googletest-1.17.0/googletest -I FirmwarePackager/third_party/googletest-1.17.0/googletest/include -pthread -o /tmp/recover_boot_script_test && /tmp/recover_boot_script_test`


------
https://chatgpt.com/codex/tasks/task_e_68bf9fdf26e08327a32fb07c0adaad00