### PR TITLE
Retry current entry when resuming install script

### DIFF
--- a/FirmwarePackager/templates/scripts/install.sh.in
+++ b/FirmwarePackager/templates/scripts/install.sh.in
@@ -169,8 +169,11 @@ if [ "$STEP" = "install" ]; then
                 continue
             fi
             if [ "$SKIP" -eq 1 ]; then
-                [ "$dest" = "$LAST_FILE" ] && SKIP=0
-                continue
+                if [ "$dest" = "$LAST_FILE" ]; then
+                    SKIP=0
+                else
+                    continue
+                fi
             fi
             LAST_FILE="$dest"
             write_state


### PR DESCRIPTION
## Summary
- Process last file again when resuming an interrupted install so partially handled files are retried

## Testing
- `shellcheck FirmwarePackager/templates/scripts/install.sh.in`
- `qmake tests.pro` *(fails: undefined reference to `MD5`, `archive_write_new`, etc.)*
- `make` *(fails: undefined reference to `MD5`, `archive_write_new`, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb34bdc9083279abfdac2c40fbd15