### PR TITLE
Initialize default owner and group in FileEntry

### DIFF
--- a/FirmwarePackager/src/core/ProjectModel.cpp
+++ b/FirmwarePackager/src/core/ProjectModel.cpp
@@ -3,11 +3,11 @@
 namespace core {
 
 FileEntry::FileEntry()
-    : recursive(false) {}
+    : owner("root"), group("root"), recursive(false) {}
 
 FileEntry::FileEntry(std::filesystem::path p, std::string i, std::string h)
     : path(std::move(p)), dest(path), id(std::move(i)), hash(std::move(h)),
-      mode(""), owner(""), group(""), recursive(false) {}
+      mode(""), owner("root"), group("root"), recursive(false) {}
 
 Project::Project() = default;
 


### PR DESCRIPTION
## Summary
- Default `FileEntry` owner and group to "root" in both constructors

## Testing
- `qmake tests.pro` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbb95ed2083278d4c1d39d3d91c38