### PR TITLE
Copy recovery scripts to last directory

### DIFF
--- a/FirmwarePackager/templates/scripts/init/sysv/S95-upgrade-recover.in
+++ b/FirmwarePackager/templates/scripts/init/sysv/S95-upgrade-recover.in
@@ -7,9 +7,10 @@
 # Default-Stop:
 # Short-Description: Run recovery after upgrade
 ### END INIT INFO
+LAST_DIR="/opt/upgrade/last"
 case "$1" in
     start)
-        /opt/upgrade/last/scripts/recover_boot.sh
+        "$LAST_DIR/scripts/recover_boot.sh"
         ;;
     *)
         echo "Usage: $0 start" >&2

--- a/FirmwarePackager/templates/scripts/install.sh.in
+++ b/FirmwarePackager/templates/scripts/install.sh.in
@@ -18,6 +18,7 @@ JOURNAL="${STATE_DIR}/${PKG_ID}.journal"
 PKG_TGZ="${PKG_DIR}/${PKG_ID}.tar.gz"
 LOCK_DIR="/opt/upgrade/locks"
 LOCK_FILE="${LOCK_DIR}/upgrade.lock"
+LAST_DIR="/opt/upgrade/last"
 
 PKG_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 
@@ -146,13 +147,12 @@ else
 fi
 
 BASE_DIR="$PKG_ROOT"
-
-LAST_DIR="/opt/upgrade/last"
+# Step 2: make recovery scripts available in the last directory
 mkdir -p "$LAST_DIR"
 rm -rf "$LAST_DIR/scripts"
 cp -r "$BASE_DIR/scripts" "$LAST_DIR/"
 
-HOOK_SRC="$BASE_DIR/scripts/init/sysv/S95-upgrade-recover"
+HOOK_SRC="$LAST_DIR/scripts/init/sysv/S95-upgrade-recover"
 if [ -f "$HOOK_SRC" ]; then
     mkdir -p /etc/init.d /etc/rcS.d
     cp "$HOOK_SRC" /etc/init.d/


### PR DESCRIPTION
## Summary
- add LAST_DIR variable to installer and copy recovery scripts to /opt/upgrade/last
- update init hook to reference the LAST_DIR recovery scripts

## Testing
- `./recover_boot_script_test` *(fails: argVal "" vs "--resume")*
- `./install_script_test` *(fails: rc 0 vs nonzero)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbc76582883278424d8df932fa25c