### PR TITLE
Support recursive folder mappings with excludes

### DIFF
--- a/FirmwarePackager/src/ui/MappingDialog.cpp
+++ b/FirmwarePackager/src/ui/MappingDialog.cpp
@@ -37,7 +37,9 @@ MappingDialog::MappingDialog(core::FileEntry& entry, QWidget* parent)
     for (const auto& e : fileEntry.excludes)
         ex << QString::fromStdString(e.string());
     excludesEdit = new QLineEdit(ex.join(","));
+    excludesEdit->setEnabled(fileEntry.recursive);
     layout->addRow("Excludes", excludesEdit);
+    connect(recursiveCheck, &QCheckBox::toggled, excludesEdit, &QWidget::setEnabled);
 
     auto *buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttons, &QDialogButtonBox::accepted, this, &MappingDialog::accept);


### PR DESCRIPTION
## Summary
- add folders as single recursive entries instead of enumerating files
- display recursive directories in the UI with blank excludes column
- enable editing exclude patterns when a mapping is recursive
- test manifest writer directory expansion and excludes

## Testing
- `g++ -std=c++17 tests/manifest_writer_test.cpp FirmwarePackager/src/core/ManifestWriter.cpp FirmwarePackager/src/core/ProjectModel.cpp FirmwarePackager/third_party/googletest-1.17.0/googletest/src/gtest-all.cc -I FirmwarePackager/src -I FirmwarePackager -I FirmwarePackager/third_party/googletest-1.17.0/googletest/include -I FirmwarePackager/third_party/googletest-1.17.0/googletest -pthread -lssl -lcrypto -o manifest_writer_test && ./manifest_writer_test`
- `g++ -std=c++17 tests/packager_test.cpp FirmwarePackager/src/core/Packager.cpp FirmwarePackager/src/core/Scanner.cpp FirmwarePackager/src/core/Hasher.cpp FirmwarePackager/src/core/ManifestWriter.cpp FirmwarePackager/src/core/ScriptWriter.cpp FirmwarePackager/src/core/IdGenerator.cpp FirmwarePackager/src/core/ProjectModel.cpp FirmwarePackager/third_party/googletest-1.17.0/googletest/src/gtest-all.cc -I FirmwarePackager/src -I FirmwarePackager -I FirmwarePackager/third_party/googletest-1.17.0/googletest/include -I FirmwarePackager/third_party/googletest-1.17.0/googletest -pthread -larchive -lssl -lcrypto -o packager_test`
- `cd .. && ./FirmwarePackager/packager_test` *(fails: payload file missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbf665dcc832780e66a637910545f