### PR TITLE
feat: persist project package identifier

### DIFF
--- a/FirmwarePackager/src/core/Packager.cpp
+++ b/FirmwarePackager/src/core/Packager.cpp
@@ -21,6 +21,7 @@ Packager::Packager(Scanner& s, Hasher& h, IManifestWriter& m,
 Project Packager::buildProject(const std::filesystem::path& root, const Scanner::PathList& exclusions) {
     Project project(root.filename().string());
     project.rootDir = root;
+    project.pkgId = idGen.generate();
     auto paths = scanner.scan(root, exclusions);
     for (const auto& p : paths) {
         std::ifstream in(p, std::ios::binary);
@@ -35,7 +36,7 @@ Project Packager::buildProject(const std::filesystem::path& root, const Scanner:
 
 void Packager::package(const Project& project) {
     logger.info("Packaging project");
-    std::string pkgId = idGen.generate();
+    std::string pkgId = project.pkgId.empty() ? idGen.generate() : project.pkgId;
     auto tempRoot = std::filesystem::temp_directory_path() / ("package-" + pkgId);
     std::filesystem::create_directories(tempRoot);
 

--- a/FirmwarePackager/src/core/ProjectModel.cpp
+++ b/FirmwarePackager/src/core/ProjectModel.cpp
@@ -9,10 +9,11 @@ FileEntry::FileEntry(std::filesystem::path p, std::string i, std::string h)
     : path(std::move(p)), dest(path), id(std::move(i)), hash(std::move(h)),
       mode(""), owner("root"), group("root"), recursive(false) {}
 
-Project::Project() = default;
+Project::Project()
+    : pkgId("") {}
 
 Project::Project(std::string name)
-    : name(std::move(name)) {}
+    : name(std::move(name)), pkgId("") {}
 
 } // namespace core
 

--- a/FirmwarePackager/src/core/ProjectModel.h
+++ b/FirmwarePackager/src/core/ProjectModel.h
@@ -24,6 +24,7 @@ struct FileEntry {
 struct Project {
     std::string name;                 // project/package name
     std::string version;              // package version
+    std::string pkgId;                // unique package identifier
     std::filesystem::path rootDir;    // project root directory
     std::filesystem::path outputDir;  // output directory
     std::vector<FileEntry> files;     // files included in project

--- a/FirmwarePackager/src/core/ProjectSerializer.cpp
+++ b/FirmwarePackager/src/core/ProjectSerializer.cpp
@@ -16,6 +16,7 @@ Project ProjectSerializer::load(const std::string& filePath) const {
     Project project;
     project.name = j.value("name", "");
     project.version = j.value("version", "");
+    project.pkgId = j.value("pkgId", "");
     project.rootDir = j.value("rootDir", "");
     project.outputDir = j.value("outputDir", "");
     if (j.contains("files")) {
@@ -43,6 +44,7 @@ void ProjectSerializer::save(const Project& project, const std::string& filePath
     json j;
     j["name"] = project.name;
     j["version"] = project.version;
+    j["pkgId"] = project.pkgId;
     j["rootDir"] = project.rootDir.string();
     j["outputDir"] = project.outputDir.string();
     j["files"] = json::array();

--- a/FirmwarePackager/src/ui/MainWindow.cpp
+++ b/FirmwarePackager/src/ui/MainWindow.cpp
@@ -206,15 +206,19 @@ void MainWindow::buildPackage() {
 }
 
 void MainWindow::openSettings() {
-    ProjectSettingsDialog dlg(rootEdit->text(), outputEdit->text(), this);
+    ProjectSettingsDialog dlg(rootEdit->text(), outputEdit->text(),
+                              QString::fromStdString(currentProject.pkgId), this);
     if (dlg.exec() == QDialog::Accepted) {
         rootEdit->setText(dlg.rootDir());
         outputEdit->setText(dlg.outputDir());
         if (!dlg.rootDir().isEmpty()) {
             currentProject = packager->buildProject(dlg.rootDir().toStdString(), core::Scanner::PathList{});
             currentProject.outputDir = dlg.outputDir().toStdString();
-            populateTable(currentProject);
+        } else {
+            currentProject.outputDir = dlg.outputDir().toStdString();
         }
+        currentProject.pkgId = dlg.pkgId().toStdString();
+        populateTable(currentProject);
     }
 }
 

--- a/FirmwarePackager/src/ui/ProjectSettingsDialog.cpp
+++ b/FirmwarePackager/src/ui/ProjectSettingsDialog.cpp
@@ -6,7 +6,8 @@
 #include <QFileDialog>
 #include <QHBoxLayout>
 
-ProjectSettingsDialog::ProjectSettingsDialog(const QString& root, const QString& output, QWidget* parent)
+ProjectSettingsDialog::ProjectSettingsDialog(const QString& root, const QString& output,
+                                             const QString& pkgId, QWidget* parent)
     : QDialog(parent) {
     setWindowTitle("Project Settings");
 
@@ -28,6 +29,9 @@ ProjectSettingsDialog::ProjectSettingsDialog(const QString& root, const QString&
     outLayout->addWidget(outBtn);
     layout->addRow("Output", outLayout);
 
+    pkgIdEdit = new QLineEdit(pkgId);
+    layout->addRow("Package ID", pkgIdEdit);
+
     auto *buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);
     connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
@@ -36,6 +40,7 @@ ProjectSettingsDialog::ProjectSettingsDialog(const QString& root, const QString&
 
 QString ProjectSettingsDialog::rootDir() const { return rootEdit->text(); }
 QString ProjectSettingsDialog::outputDir() const { return outputEdit->text(); }
+QString ProjectSettingsDialog::pkgId() const { return pkgIdEdit->text(); }
 
 void ProjectSettingsDialog::browseRoot() {
     QString dir = QFileDialog::getExistingDirectory(this, "Select Root Directory");

--- a/FirmwarePackager/src/ui/ProjectSettingsDialog.h
+++ b/FirmwarePackager/src/ui/ProjectSettingsDialog.h
@@ -7,14 +7,17 @@
 class ProjectSettingsDialog : public QDialog {
     Q_OBJECT
 public:
-    ProjectSettingsDialog(const QString& root, const QString& output, QWidget* parent = nullptr);
+    ProjectSettingsDialog(const QString& root, const QString& output,
+                         const QString& pkgId, QWidget* parent = nullptr);
     QString rootDir() const;
     QString outputDir() const;
+    QString pkgId() const;
 private slots:
     void browseRoot();
     void browseOutput();
 private:
     QLineEdit* rootEdit;
     QLineEdit* outputEdit;
+    QLineEdit* pkgIdEdit;
 };
 

--- a/tests/project_serializer_test.cpp
+++ b/tests/project_serializer_test.cpp
@@ -1,0 +1,21 @@
+#include <gtest/gtest.h>
+#include "core/ProjectSerializer.h"
+#include <filesystem>
+
+TEST(ProjectSerializerTest, PkgIdPersists) {
+    core::Project project("demo");
+    project.pkgId = "pkg123";
+    project.rootDir = std::filesystem::temp_directory_path();
+    project.outputDir = std::filesystem::temp_directory_path();
+    core::ProjectSerializer serializer;
+    std::filesystem::path file = std::filesystem::temp_directory_path() / "project.json";
+    serializer.save(project, file.string());
+    core::Project loaded = serializer.load(file.string());
+    EXPECT_EQ(loaded.pkgId, project.pkgId);
+    std::filesystem::remove(file);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- include pkgId in project model and JSON serializer
- keep pkgId through UI settings and package builds
- add unit test for pkgId persistence

## Testing
- `g++ -std=c++17 tests/hasher_test.cpp FirmwarePackager/src/core/Hasher.cpp FirmwarePackager/src/core/Logger.cpp -I FirmwarePackager/src -lssl -lcrypto -lgtest -lgtest_main -lpthread -o hasher_test`
- `./hasher_test >/tmp/hasher_test.log && tail -n 20 /tmp/hasher_test.log`
- `g++ -std=c++17 tests/project_serializer_test.cpp FirmwarePackager/src/core/ProjectSerializer.cpp FirmwarePackager/src/core/ProjectModel.cpp -I FirmwarePackager/src -I FirmwarePackager/third_party -lgtest -lgtest_main -lpthread -o project_serializer_test`
- `./project_serializer_test >/tmp/project_serializer_test.log && tail -n 20 /tmp/project_serializer_test.log`


------
https://chatgpt.com/codex/tasks/task_e_68bfc12dd3b08327b048638e09e4075a