### PR TITLE
Allow configurable template path for script writer

### DIFF
--- a/FirmwarePackager/src/core/Packager.h
+++ b/FirmwarePackager/src/core/Packager.h
@@ -21,7 +21,8 @@ public:
 class Packager : public IPackager {
 public:
     Packager(Scanner& scanner, Hasher& hasher, IManifestWriter& manifest,
-             IScriptWriter& script, IIdGenerator& idGen, ILogger& logger);
+             IScriptWriter& script, IIdGenerator& idGen, ILogger& logger,
+             std::filesystem::path templateRoot);
 
     Project buildProject(const std::filesystem::path& root, const Scanner::PathList& exclusions) override;
     void package(const Project& project) override;
@@ -33,6 +34,7 @@ private:
     IScriptWriter& script;
     IIdGenerator& idGen;
     ILogger& logger;
+    std::filesystem::path templateRoot;
 
     void createArchive(const std::filesystem::path& dir, const std::filesystem::path& archive);
 };

--- a/FirmwarePackager/src/core/ScriptWriter.cpp
+++ b/FirmwarePackager/src/core/ScriptWriter.cpp
@@ -17,7 +17,8 @@ std::string replaceAll(std::string str, const std::string& from, const std::stri
 }
 
 void ScriptWriter::write(const Project& project, const std::filesystem::path& output,
-                         const std::string& pkgId) const {
+                         const std::string& pkgId,
+                         const std::filesystem::path& templateRoot) const {
     // scripts are always emitted into a "scripts" subdirectory of the output
     std::filesystem::path outRoot = output / "scripts";
     std::filesystem::create_directories(outRoot);
@@ -26,12 +27,12 @@ void ScriptWriter::write(const Project& project, const std::filesystem::path& ou
     std::string pkgName = project.name;
     std::string pkgVersion = project.version;
 
-    std::filesystem::path tplDir = std::filesystem::path("templates") / "scripts";
+    std::filesystem::path tplDir = templateRoot / "scripts";
 
     for (const auto& entry : std::filesystem::recursive_directory_iterator(tplDir)) {
         if (entry.is_directory()) continue;
 
-        std::ifstream in(entry.path());
+        std::ifstream in(entry.path(), std::ios::binary);
         if (!in) continue;
         std::stringstream buffer;
         buffer << in.rdbuf();
@@ -47,7 +48,7 @@ void ScriptWriter::write(const Project& project, const std::filesystem::path& ou
             outFile.replace_extension("");
         }
         std::filesystem::create_directories(outFile.parent_path());
-        std::ofstream out(outFile);
+        std::ofstream out(outFile, std::ios::binary);
         out << content;
         out.close();
         std::filesystem::permissions(

--- a/FirmwarePackager/src/core/ScriptWriter.h
+++ b/FirmwarePackager/src/core/ScriptWriter.h
@@ -10,14 +10,16 @@ class IScriptWriter {
 public:
     virtual ~IScriptWriter() = default;
     virtual void write(const Project& project, const std::filesystem::path& output,
-                      const std::string& pkgId) const = 0;
+                      const std::string& pkgId,
+                      const std::filesystem::path& templateRoot) const = 0;
 };
 
 class ScriptWriter : public IScriptWriter {
 public:
     ScriptWriter() = default;
     void write(const Project& project, const std::filesystem::path& output,
-               const std::string& pkgId) const override;
+               const std::string& pkgId,
+               const std::filesystem::path& templateRoot) const override;
 };
 
 } // namespace core

--- a/FirmwarePackager/src/ui/MainWindow.cpp
+++ b/FirmwarePackager/src/ui/MainWindow.cpp
@@ -17,6 +17,7 @@
 #include <QTemporaryDir>
 #include <QDialogButtonBox>
 #include <QVBoxLayout>
+#include <QCoreApplication>
 #include <fstream>
 #include <vector>
 #include <iterator>
@@ -117,7 +118,8 @@ MainWindow::MainWindow(QWidget* parent)
     connect(editAct, &QAction::triggered, this, &MainWindow::editMapping);
 
     guiLogger = new GuiLogger(logPane);
-    packager = std::make_unique<core::Packager>(scanner, hasher, manifest, script, idGen, *guiLogger);
+    auto tplRoot = std::filesystem::path(QCoreApplication::applicationDirPath().toStdString()) / "templates";
+    packager = std::make_unique<core::Packager>(scanner, hasher, manifest, script, idGen, *guiLogger, tplRoot);
 }
 
 void MainWindow::newProject() {


### PR DESCRIPTION
## Summary
- pass template directory into ScriptWriter and open outputs in binary mode
- thread template root through Packager and GUI creation
- adjust tests to locate templates from temporary directories and verify scripts lack CRLF endings

## Testing
- `./build/script_writer_test`
- `./build/packager_test`
- `./build/hasher_test`
- `./build/id_generator_test`
- `./build/manifest_writer_test`
- `./build/project_serializer_test`
- `./build/scanner_test`
- `./build/install_script_test`
- `./build/recover_boot_script_test`


------
https://chatgpt.com/codex/tasks/task_e_68bfc393a75c8327881aa779f661c754