### PR TITLE
Add sync calls to install script and test

### DIFF
--- a/FirmwarePackager/templates/scripts/install.sh.in
+++ b/FirmwarePackager/templates/scripts/install.sh.in
@@ -194,11 +194,14 @@ if [ "$STEP" = "install" ]; then
                 backup="$BACKUP_DIR/$dest"
                 mkdir -p "$(dirname "$backup")"
                 cp "$dest" "$backup"
+                sync
                 mv "$dest" "$dest.old"
+                sync
                 echo "BACKUP|$dest|$backup" >> "$JOURNAL"
             fi
 
             cp "$BASE_DIR/$rel" "$dest.new"
+            sync
             chmod "$mode" "$dest.new" 2>/dev/null || true
             if [ -n "$owner" ] && [ -n "$group" ]; then
                 chown "$owner:$group" "$dest.new" 2>/dev/null || true
@@ -206,11 +209,13 @@ if [ "$STEP" = "install" ]; then
             calc_new=$(md5sum "$dest.new" | awk '{print $1}')
             [ "$calc_new" = "$md5" ] || fail
             mv "$dest.new" "$dest"
+            sync
             calc_final=$(md5sum "$dest" | awk '{print $1}')
             [ "$calc_final" = "$md5" ] || fail
             echo "REPLACED|$dest|$backup" >> "$JOURNAL"
 
         done
+        sync
     } < "$BASE_DIR/manifest.tsv"
 fi
 

--- a/tests/install_script_test.cpp
+++ b/tests/install_script_test.cpp
@@ -52,6 +52,10 @@ void cleanupState(){
 }
 }
 
+TEST(InstallScript, ContainsSyncCommand){
+    EXPECT_EQ(std::system("grep -q sync FirmwarePackager/templates/scripts/install.sh.in"), 0);
+}
+
 TEST(InstallScript, DetectsMd5Mismatch){
     cleanupState();
     path pkg = temp_directory_path()/"pkg_md5"; remove_all(pkg);


### PR DESCRIPTION
## Summary
- flush file operations in install script with `sync`
- test for presence of sync in install script

## Testing
- `g++ -std=c++17 tests/install_script_test.cpp -lgtest -lgtest_main -pthread -lcrypto -o install_script_test`
- `./install_script_test`


------
https://chatgpt.com/codex/tasks/task_e_68bfc8a22e388327b553cdc80fe9160f