### PR TITLE
Use relative paths for payload layout

### DIFF
--- a/FirmwarePackager/src/core/Packager.cpp
+++ b/FirmwarePackager/src/core/Packager.cpp
@@ -50,7 +50,7 @@ void Packager::package(const Project& project) {
 
     for (const auto& f : project.files) {
         auto src = project.rootDir / f.path;
-        auto destRoot = payloadDir / f.dest;
+        auto destRoot = payloadDir / f.path;
         if (f.recursive || std::filesystem::is_directory(src)) {
             if (!std::filesystem::exists(src)) continue;
             for (std::filesystem::recursive_directory_iterator it(src), end; it != end; ++it) {
@@ -69,7 +69,8 @@ void Packager::package(const Project& project) {
                     continue;
                 }
                 if (!it->is_regular_file()) continue;
-                auto dst = payloadDir / f.dest / relToDir;
+                auto relToRoot = std::filesystem::relative(it->path(), project.rootDir);
+                auto dst = payloadDir / relToRoot;
                 std::filesystem::create_directories(dst.parent_path());
                 std::filesystem::copy_file(it->path(), dst, std::filesystem::copy_options::overwrite_existing);
             }

--- a/FirmwarePackager/templates/scripts/install.sh.in
+++ b/FirmwarePackager/templates/scripts/install.sh.in
@@ -183,7 +183,7 @@ if [ "$STEP" = "install" ]; then
             LAST_FILE="$dest"
             write_state
 
-            calc=$(md5sum "$BASE_DIR/$rel" | awk '{print $1}')
+            calc=$(md5sum "$BASE_DIR/payload/$rel" | awk '{print $1}')
             [ "$calc" = "$md5" ] || fail
 
             ddir=$(dirname "$dest")
@@ -200,7 +200,7 @@ if [ "$STEP" = "install" ]; then
                 echo "BACKUP|$dest|$backup" >> "$JOURNAL"
             fi
 
-            cp "$BASE_DIR/$rel" "$dest.new"
+            cp "$BASE_DIR/payload/$rel" "$dest.new"
             sync
             chmod "$mode" "$dest.new" 2>/dev/null || true
             if [ -n "$owner" ] && [ -n "$group" ]; then

--- a/tests/install_script_test.cpp
+++ b/tests/install_script_test.cpp
@@ -60,7 +60,8 @@ TEST(InstallScript, DetectsMd5Mismatch){
     cleanupState();
     path pkg = temp_directory_path()/"pkg_md5"; remove_all(pkg);
     writeScript(pkg);
-    { std::ofstream(pkg/"file.txt")<<"data"; }
+    create_directories(pkg/"payload");
+    { std::ofstream(pkg/"payload"/"file.txt")<<"data"; }
     std::ofstream manifest(pkg/"manifest.tsv");
     manifest<<"relpath\tdest\tmode\towner\tgroup\tmd5\n";
     manifest<<"file.txt\t"<<(pkg/"out.txt").string()<<"\t0644\troot\troot\tdeadbeefdeadbeefdeadbeefdeadbeef\n";
@@ -84,11 +85,12 @@ TEST(InstallScript, RollsBackOnFailure){
     cleanupState();
     path pkg = temp_directory_path()/"pkg_rb"; remove_all(pkg);
     writeScript(pkg);
-    { std::ofstream(pkg/"a.txt")<<"newA"; }
-    { std::ofstream(pkg/"b.txt")<<"newB"; }
+    create_directories(pkg/"payload");
+    { std::ofstream(pkg/"payload"/"a.txt")<<"newA"; }
+    { std::ofstream(pkg/"payload"/"b.txt")<<"newB"; }
     path destA = pkg/"destA.txt"; { std::ofstream(destA)<<"oldA"; }
     path destB = pkg/"destB.txt"; // does not exist
-    std::string hashA = md5File(pkg/"a.txt");
+    std::string hashA = md5File(pkg/"payload"/"a.txt");
     std::ofstream manifest(pkg/"manifest.tsv");
     manifest<<"relpath\tdest\tmode\towner\tgroup\tmd5\n";
     manifest<<"a.txt\t"<<destA.string()<<"\t0644\troot\troot\t"<<hashA<<"\n";

--- a/tests/packager_test.cpp
+++ b/tests/packager_test.cpp
@@ -68,10 +68,10 @@ TEST(PackagerTest, GeneratesArchiveWithExpectedContents) {
     EXPECT_FALSE(exists(extractDir / "payload"));
     EXPECT_FALSE(exists(extractDir / "manifest.tsv"));
 
-    path payloadFile = packageDir / "payload" / "destdir" / "a.txt";
+    path payloadFile = packageDir / "payload" / "dir" / "a.txt";
     ASSERT_TRUE(exists(payloadFile));
-    EXPECT_FALSE(exists(packageDir / "payload" / "destdir" / "sub" / "b.txt"));
-    EXPECT_FALSE(exists(packageDir / "payload" / "destdir" / "exclude.txt"));
+    EXPECT_FALSE(exists(packageDir / "payload" / "dir" / "sub" / "b.txt"));
+    EXPECT_FALSE(exists(packageDir / "payload" / "dir" / "exclude.txt"));
     std::ifstream in(payloadFile); std::string data; std::getline(in, data); EXPECT_EQ(data, "data");
 
     path manifestPath = packageDir / "manifest.tsv";


### PR DESCRIPTION
## Summary
- Place packaged files under `payload/<relpath>` instead of destination path.
- Update install script to read files from `payload/$rel` when verifying and staging.
- Adjust tests for new payload layout and confirm manifest `relpath` column.

## Testing
- `/tmp/packager_test`
- `/tmp/install_script_test`
- `/tmp/manifest_writer_test`


------
https://chatgpt.com/codex/tasks/task_e_68bfcda6d3808327a93da4a40c346655