### PR TITLE
Refactor installer state machine

### DIFF
--- a/FirmwarePackager/templates/scripts/install.sh.in
+++ b/FirmwarePackager/templates/scripts/install.sh.in
@@ -31,7 +31,6 @@ log() {
     printf '%s %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$*" | tee -a "$LOG_FILE"
 }
 
-STATUS="INIT"
 STEP=""
 LAST_FILE=""
 STORE=""
@@ -56,7 +55,6 @@ done
 
 write_state() {
 cat >"$STATE_FILE" <<STATE
-STATUS=$STATUS
 STEP=$STEP
 JOURNAL=$JOURNAL
 PKG_TGZ=$PKG_TGZ
@@ -100,8 +98,7 @@ release_lock() {
 
 fail() {
     trap - EXIT
-    STATUS="FAIL"
-    STEP="rollback"
+    STEP="FAILED"
     write_state
     rollback
     release_lock
@@ -137,11 +134,20 @@ if [ "$RESUME" -eq 1 ]; then
     [ -f "$STATE_FILE" ] || exit 1
     . "$STATE_FILE"
     [ -f "$JOURNAL" ] || : > "$JOURNAL"
+    if [ "$STEP" != "DONE" ]; then
+        rollback
+        : > "$JOURNAL"
+        STEP="PREPARE"
+        LAST_FILE=""
+        write_state
+    fi
 else
     : > "$JOURNAL"
-    STATUS="RUNNING"
-    STEP="store"
+    STEP="PREPARE"
     write_state
+fi
+
+if [ "$STEP" = "PREPARE" ]; then
     if [ -n "$STORE" ]; then
         cp "$STORE" "$PKG_TGZ"
     else
@@ -151,7 +157,7 @@ else
             cp "$src" "$PKG_TGZ"
         fi
     fi
-    STEP="install"
+    STEP="BACKUP"
     write_state
 fi
 
@@ -171,7 +177,7 @@ if [ -f "$HOOK_SRC" ]; then
     fi
 fi
 
-if [ "$STEP" = "install" ]; then
+if [ "$STEP" = "BACKUP" ]; then
     SKIP=0
     if [ "$RESUME" -eq 1 ] && [ -n "$LAST_FILE" ]; then
         SKIP=1
@@ -226,11 +232,12 @@ if [ "$STEP" = "install" ]; then
         done
         sync
     } < "$BASE_DIR/manifest.tsv"
+    STEP="COMMIT"
+    write_state
 fi
 
 trap - EXIT
-STATUS="SUCCESS"
-STEP="done"
+STEP="DONE"
 LAST_FILE=""
 write_state
 cleanup_success

--- a/FirmwarePackager/templates/scripts/recover_boot.sh.in
+++ b/FirmwarePackager/templates/scripts/recover_boot.sh.in
@@ -10,8 +10,8 @@ for st in "$STATE_DIR"/*.state; do
     [ -e "$st" ] || continue
 
     # Skip packages that have already finished
-    status=$(grep '^STATUS=' "$st" | cut -d= -f2)
-    if [ "$status" = "SUCCESS" ] || [ "$status" = "FAIL" ]; then
+    step=$(grep '^STEP=' "$st" | cut -d= -f2)
+    if [ "$step" = "DONE" ] || [ "$step" = "FAILED" ]; then
         continue
     fi
 

--- a/docs/state_machine.md
+++ b/docs/state_machine.md
@@ -6,16 +6,20 @@ survive power loss or reboots.
 
 ## States
 
-* **init** – First entry point.  The package archive is copied to
-  `/opt/upgrade/packages/<PKG_ID>.tar.gz` and the next state is saved.
-* **copy** – Individual payload files are installed.  Each successfully
-  installed file is appended to the journal file
-  `/opt/upgrade/state/<PKG_ID>.journal`.
-* **rollback** – Invoked when an error occurs.  The journal is replayed
-  to remove previously installed files.
-* **done** – Installation completed.  State and journal files are
+* **PREPARE** – First entry point. The package archive is copied to
+  `/opt/upgrade/packages/<PKG_ID>.tar.gz` and recovery hooks are
+  installed.
+* **BACKUP** – Individual payload files are verified, backed up and
+  replaced. Each successfully installed file is appended to the journal
+  file `/opt/upgrade/state/<PKG_ID>.journal`.
+* **COMMIT** – All files have been applied and the system is ready to
+  finalize the upgrade.
+* **DONE** – Installation completed. State and journal files are
   removed.
+* **FAILED** – An error occurred and rollback was executed. The state
+  file is kept for inspection.
 
-The current state is stored in `/opt/upgrade/state/<PKG_ID>.state`.
+The current step is stored in `/opt/upgrade/state/<PKG_ID>.state` which
+contains the fields `STEP`, `JOURNAL`, `PKG_TGZ` and `LAST_FILE`.
 `recover_boot.sh` scans this directory on boot and replays unfinished
 installations by running the corresponding `install.sh --resume`.

--- a/tests/install_script_test.cpp
+++ b/tests/install_script_test.cpp
@@ -75,7 +75,7 @@ TEST(InstallScript, DetectsMd5Mismatch){
     EXPECT_FALSE(exists(pkg/"out.txt"));
     std::ifstream st("/opt/upgrade/state/TESTPKG.state");
     std::stringstream s; s<<st.rdbuf();
-    EXPECT_NE(s.str().find("STATUS=FAIL"), std::string::npos);
+    EXPECT_NE(s.str().find("STEP=FAILED"), std::string::npos);
     cleanupState();
     remove(archive);
     remove_all(pkg);

--- a/tests/recover_boot_script_test.cpp
+++ b/tests/recover_boot_script_test.cpp
@@ -15,7 +15,7 @@ TEST(RecoverBootScript, RunsInstallWithResumeAndKeepsState) {
 
     std::string id = "testpkg";
     path stateFile = stateDir / (id + ".state");
-    { std::ofstream(stateFile) << "STATUS=RUNNING\n"; }
+    { std::ofstream(stateFile) << "STEP=PREPARE\n"; }
 
     path temp = temp_directory_path() / "recover_pkg";
     remove_all(temp);
@@ -66,7 +66,7 @@ TEST(RecoverBootScript, SkipsFinishedInstallations) {
 
     std::string id = "testpkg";
     path stateFile = stateDir / (id + ".state");
-    { std::ofstream(stateFile) << "STATUS=SUCCESS\n"; }
+    { std::ofstream(stateFile) << "STEP=DONE\n"; }
 
     path temp = temp_directory_path() / "recover_pkg";
     remove_all(temp);
@@ -112,7 +112,7 @@ TEST(RecoverBootScript, SkipsFailedInstallations) {
 
     std::string id = "testpkg";
     path stateFile = stateDir / (id + ".state");
-    { std::ofstream(stateFile) << "STATUS=FAIL\n"; }
+    { std::ofstream(stateFile) << "STEP=FAILED\n"; }
 
     path temp = temp_directory_path() / "recover_pkg";
     remove_all(temp);
@@ -158,7 +158,7 @@ TEST(RecoverBootScript, LeavesTempDirOnInstallError) {
 
     std::string id = "testpkg";
     path stateFile = stateDir / (id + ".state");
-    { std::ofstream(stateFile) << "STATUS=RUNNING\n"; }
+    { std::ofstream(stateFile) << "STEP=PREPARE\n"; }
 
     path baseTmp = temp_directory_path() / "recover_pkg_err";
     remove_all(baseTmp);


### PR DESCRIPTION
## Summary
- streamline installer state handling with PREPARE/BACKUP/COMMIT/DONE phases
- reset and rollback before resuming incomplete upgrades
- document new step fields and update recovery script and tests

## Testing
- `g++ -std=c++17 tests/install_script_test.cpp FirmwarePackager/third_party/googletest-1.17.0/googletest/src/gtest-all.cc -IFirmwarePackager/third_party/googletest-1.17.0/googletest/include -IFirmwarePackager/third_party/googletest-1.17.0/googletest -pthread -lcrypto -o /tmp/install_test && /tmp/install_test >/tmp/install_test.log && tail -n 20 /tmp/install_test.log`
- `g++ -std=c++17 tests/recover_boot_script_test.cpp FirmwarePackager/third_party/googletest-1.17.0/googletest/src/gtest-all.cc -IFirmwarePackager/third_party/googletest-1.17.0/googletest/include -IFirmwarePackager/third_party/googletest-1.17.0/googletest -pthread -o /tmp/recover_test && /tmp/recover_test >/tmp/recover_test.log && tail -n 20 /tmp/recover_test.log`

------
https://chatgpt.com/codex/tasks/task_e_68bfd61f7e4c8327b7db998d70903b87