### PR TITLE
Separate journal storage from state directory

### DIFF
--- a/FirmwarePackager/templates/scripts/install.sh.in
+++ b/FirmwarePackager/templates/scripts/install.sh.in
@@ -14,7 +14,8 @@ STATE_DIR="/opt/upgrade/state"
 PKG_DIR="/opt/upgrade/packages"
 BACKUP_DIR="/opt/upgrade/backup/${PKG_ID}"
 STATE_FILE="${STATE_DIR}/${PKG_ID}.state"
-JOURNAL="${STATE_DIR}/${PKG_ID}.journal"
+JOURNAL_DIR="/opt/upgrade/journal"
+JOURNAL_FILE="${JOURNAL_DIR}/${PKG_ID}.journal"
 PKG_TGZ="${PKG_DIR}/${PKG_ID}.tar.gz"
 LOCK_DIR="/opt/upgrade/locks"
 LOCK_FILE="${LOCK_DIR}/upgrade.lock"
@@ -56,15 +57,15 @@ done
 write_state() {
 cat >"$STATE_FILE" <<STATE
 STEP=$STEP
-JOURNAL=$JOURNAL
+JOURNAL=$JOURNAL_FILE
 PKG_TGZ=$PKG_TGZ
 LAST_FILE=$LAST_FILE
 STATE
 }
 
 rollback() {
-    [ -f "$JOURNAL" ] || return 0
-    awk '{l[NR]=$0} END{for(i=NR;i>=1;i--) print l[i]}' "$JOURNAL" | \
+    [ -f "$JOURNAL_FILE" ] || return 0
+    awk '{l[NR]=$0} END{for(i=NR;i>=1;i--) print l[i]}' "$JOURNAL_FILE" | \
     while IFS="|" read -r action dest backup; do
         case "$action" in
             REPLACED)
@@ -116,7 +117,7 @@ cleanup_success() {
             done
         } < "$BASE_DIR/manifest.tsv"
     fi
-    rm -f "$JOURNAL" "$STATE_FILE" "$PKG_TGZ"
+    rm -f "$JOURNAL_FILE" "$STATE_FILE" "$PKG_TGZ"
     rm -rf "$BACKUP_DIR"
     release_lock
 }
@@ -124,7 +125,7 @@ cleanup_success() {
 trap fail INT TERM HUP QUIT
 trap fail EXIT
 
-mkdir -p "$STATE_DIR" "$PKG_DIR" "$BACKUP_DIR" "$LOCK_DIR"
+mkdir -p "$STATE_DIR" "$JOURNAL_DIR" "$PKG_DIR" "$BACKUP_DIR" "$LOCK_DIR"
 if ! acquire_lock; then
     log "Another upgrade is in progress" >&2
     exit 1
@@ -133,16 +134,17 @@ fi
 if [ "$RESUME" -eq 1 ]; then
     [ -f "$STATE_FILE" ] || exit 1
     . "$STATE_FILE"
-    [ -f "$JOURNAL" ] || : > "$JOURNAL"
+    JOURNAL_FILE="$JOURNAL"
+    [ -f "$JOURNAL_FILE" ] || : > "$JOURNAL_FILE"
     if [ "$STEP" != "DONE" ]; then
         rollback
-        : > "$JOURNAL"
+        : > "$JOURNAL_FILE"
         STEP="PREPARE"
         LAST_FILE=""
         write_state
     fi
 else
-    : > "$JOURNAL"
+    : > "$JOURNAL_FILE"
     STEP="PREPARE"
     write_state
 fi
@@ -212,7 +214,7 @@ if [ "$STEP" = "BACKUP" ]; then
                 sync
                 mv "$dest" "$dest.old"
                 sync
-                echo "BACKUP|$dest|$backup" >> "$JOURNAL"
+                echo "BACKUP|$dest|$backup" >> "$JOURNAL_FILE"
             fi
 
             cp "$BASE_DIR/payload/$rel" "$dest.new"
@@ -227,7 +229,7 @@ if [ "$STEP" = "BACKUP" ]; then
             sync
             calc_final=$(md5sum "$dest" | awk '{print $1}')
             [ "$calc_final" = "$md5" ] || fail
-            echo "REPLACED|$dest|$backup" >> "$JOURNAL"
+            echo "REPLACED|$dest|$backup" >> "$JOURNAL_FILE"
 
         done
         sync

--- a/FirmwarePackager/templates/scripts/recover_boot.sh.in
+++ b/FirmwarePackager/templates/scripts/recover_boot.sh.in
@@ -5,6 +5,7 @@
 
 STATE_DIR="/opt/upgrade/state"
 PKG_DIR="/opt/upgrade/packages"
+JOURNAL_DIR="/opt/upgrade/journal"
 
 for st in "$STATE_DIR"/*.state; do
     [ -e "$st" ] || continue

--- a/docs/state_machine.md
+++ b/docs/state_machine.md
@@ -1,8 +1,8 @@
 # Installer State Machine
 
 The generated `install.sh` script performs upgrades using a small
-state machine.  Progress is persisted under `/opt/upgrade/state` to
-survive power loss or reboots.
+state machine.  Progress is persisted under `/opt/upgrade/state` and
+`/opt/upgrade/journal` to survive power loss or reboots.
 
 ## States
 
@@ -11,7 +11,7 @@ survive power loss or reboots.
   installed.
 * **BACKUP** – Individual payload files are verified, backed up and
   replaced. Each successfully installed file is appended to the journal
-  file `/opt/upgrade/state/<PKG_ID>.journal`.
+  file `/opt/upgrade/journal/<PKG_ID>.journal`.
 * **COMMIT** – All files have been applied and the system is ready to
   finalize the upgrade.
 * **DONE** – Installation completed. State and journal files are

--- a/tests/install_script_test.cpp
+++ b/tests/install_script_test.cpp
@@ -47,7 +47,7 @@ void writeScript(const path& dir){
 void cleanupState(){
     remove_all("/opt/upgrade/backup/TESTPKG");
     remove("/opt/upgrade/state/TESTPKG.state");
-    remove("/opt/upgrade/state/TESTPKG.journal");
+    remove("/opt/upgrade/journal/TESTPKG.journal");
     remove("/opt/upgrade/packages/TESTPKG.tar.gz");
 }
 }


### PR DESCRIPTION
## Summary
- store installation journals under `/opt/upgrade/journal`
- adjust install and recovery scripts to use new journal paths
- update tests and docs for new journal location

## Testing
- `./hasher_test`
- `./id_generator_test`
- `./manifest_writer_test`
- `./project_serializer_test`
- `./scanner_test`
- `./script_writer_test`
- `./recover_boot_script_test`
- `./install_script_test`
- `./packager_test`


------
https://chatgpt.com/codex/tasks/task_e_68bfdcd749a483279eb3201847c31e0f