### PR TITLE
Default file and folder modes

### DIFF
--- a/FirmwarePackager/src/core/ProjectModel.cpp
+++ b/FirmwarePackager/src/core/ProjectModel.cpp
@@ -1,4 +1,5 @@
 #include "ProjectModel.h"
+#include <system_error>
 
 namespace core {
 
@@ -7,7 +8,14 @@ FileEntry::FileEntry()
 
 FileEntry::FileEntry(std::filesystem::path p, std::string i, std::string h)
     : path(std::move(p)), dest(path), id(std::move(i)), hash(std::move(h)),
-      mode(""), owner("root"), group("root"), recursive(false) {}
+      mode(""), owner("root"), group("root"), recursive(false) {
+    std::error_code ec;
+    if (std::filesystem::is_directory(path, ec)) {
+        mode = "0755";
+    } else {
+        mode = "0644";
+    }
+}
 
 Project::Project()
     : pkgId("") {}

--- a/FirmwarePackager/src/core/ProjectSerializer.cpp
+++ b/FirmwarePackager/src/core/ProjectSerializer.cpp
@@ -1,6 +1,8 @@
 #include "ProjectSerializer.h"
 
 #include <fstream>
+#include <filesystem>
+#include <system_error>
 #include <nlohmann/json.hpp>
 
 namespace core {
@@ -33,6 +35,12 @@ Project ProjectSerializer::load(const std::string& filePath) const {
             if (item.contains("excludes")) {
                 for (const auto& ex : item["excludes"])
                     entry.excludes.push_back(ex.get<std::string>());
+            }
+            if (entry.mode.empty()) {
+                std::error_code ec;
+                bool isDir = entry.recursive ||
+                              std::filesystem::is_directory(project.rootDir / entry.path, ec);
+                entry.mode = isDir ? "0755" : "0644";
             }
             project.files.push_back(entry);
         }

--- a/FirmwarePackager/src/ui/MainWindow.cpp
+++ b/FirmwarePackager/src/ui/MainWindow.cpp
@@ -297,6 +297,7 @@ void MainWindow::addFolder() {
         entry.path = rel;
         entry.dest = rel;
         entry.recursive = true;
+        entry.mode = "0755";
         currentProject.files.push_back(entry);
     }
     populateTable(currentProject);

--- a/tests/project_serializer_test.cpp
+++ b/tests/project_serializer_test.cpp
@@ -15,6 +15,27 @@ TEST(ProjectSerializerTest, PkgIdPersists) {
     std::filesystem::remove(file);
 }
 
+TEST(ProjectSerializerTest, DefaultModesApplied) {
+    core::Project project("demo");
+    project.rootDir = std::filesystem::temp_directory_path();
+    project.outputDir = std::filesystem::temp_directory_path();
+
+    core::FileEntry fileEntry; fileEntry.path = "file"; fileEntry.dest = "file";
+    project.files.push_back(fileEntry);
+
+    core::FileEntry dirEntry; dirEntry.path = "dir"; dirEntry.dest = "dir"; dirEntry.recursive = true;
+    project.files.push_back(dirEntry);
+
+    core::ProjectSerializer serializer;
+    std::filesystem::path file = std::filesystem::temp_directory_path() / "project_modes.json";
+    serializer.save(project, file.string());
+    core::Project loaded = serializer.load(file.string());
+    ASSERT_EQ(loaded.files.size(), 2);
+    EXPECT_EQ(loaded.files[0].mode, "0644");
+    EXPECT_EQ(loaded.files[1].mode, "0755");
+    std::filesystem::remove(file);
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
## Summary
- Infer file permissions when creating FileEntry instances
- Apply default folder mode in UI and project loading
- Test that serializer applies default modes for files and directories

## Testing
- `g++ -std=c++17 tests/hasher_test.cpp FirmwarePackager/src/core/Hasher.cpp FirmwarePackager/third_party/googletest-1.17.0/googletest/src/gtest-all.cc FirmwarePackager/third_party/googletest-1.17.0/googlemock/src/gmock-all.cc -I FirmwarePackager/src -I FirmwarePackager -I FirmwarePackager/third_party/googletest-1.17.0/googletest -I FirmwarePackager/third_party/googletest-1.17.0/googletest/include -I FirmwarePackager/third_party/googletest-1.17.0/googlemock -I FirmwarePackager/third_party/googletest-1.17.0/googlemock/include -pthread -lcrypto -o tests/hasher_test`
- `./tests/hasher_test > /tmp/hasher_test.log && cat /tmp/hasher_test.log`
- `g++ -std=c++17 tests/project_serializer_test.cpp FirmwarePackager/src/core/*.cpp FirmwarePackager/third_party/googletest-1.17.0/googletest/src/gtest-all.cc FirmwarePackager/third_party/googletest-1.17.0/googlemock/src/gmock-all.cc -I FirmwarePackager/src -I FirmwarePackager -I FirmwarePackager/third_party/googletest-1.17.0/googletest -I FirmwarePackager/third_party/googletest-1.17.0/googletest/include -I FirmwarePackager/third_party/googletest-1.17.0/googlemock -I FirmwarePackager/third_party/googletest-1.17.0/googlemock/include -pthread -larchive -lz -lcrypto -o tests/project_serializer_test`
- `./tests/project_serializer_test > /tmp/project_serializer_test.log && cat /tmp/project_serializer_test.log`


------
https://chatgpt.com/codex/tasks/task_e_68bfe245a6b8832788b4288509b56a85