### PR TITLE
Ensure preview script uses template root

### DIFF
--- a/FirmwarePackager/src/ui/MainWindow.cpp
+++ b/FirmwarePackager/src/ui/MainWindow.cpp
@@ -24,7 +24,8 @@
 #include <filesystem>
 
 MainWindow::MainWindow(QWidget* parent)
-    : QMainWindow(parent), guiLogger(nullptr) {
+    : QMainWindow(parent), guiLogger(nullptr),
+      tplRoot(std::filesystem::path(QCoreApplication::applicationDirPath().toStdString()) / "templates") {
     setWindowTitle("Upgrade Builder");
 
     // file menu
@@ -118,7 +119,6 @@ MainWindow::MainWindow(QWidget* parent)
     connect(editAct, &QAction::triggered, this, &MainWindow::editMapping);
 
     guiLogger = new GuiLogger(logPane);
-    auto tplRoot = std::filesystem::path(QCoreApplication::applicationDirPath().toStdString()) / "templates";
     packager = std::make_unique<core::Packager>(scanner, hasher, manifest, script, idGen, *guiLogger, tplRoot);
 }
 
@@ -342,7 +342,7 @@ void MainWindow::previewScript() {
         return;
     }
     try {
-        script.write(currentProject, tempDir.path().toStdString(), idGen.generate());
+        script.write(currentProject, tempDir.path().toStdString(), idGen.generate(), tplRoot);
     } catch (const std::exception& e) {
         QMessageBox::critical(this, "Error", e.what());
         return;

--- a/FirmwarePackager/src/ui/MainWindow.h
+++ b/FirmwarePackager/src/ui/MainWindow.h
@@ -10,6 +10,7 @@
 #include "src/core/ProjectModel.h"
 #include "src/core/ProjectSerializer.h"
 #include "GuiLogger.h"
+#include <filesystem>
 
 class MainWindow : public QMainWindow {
     Q_OBJECT
@@ -46,6 +47,7 @@ private:
     core::ScriptWriter script;
     core::ProjectSerializer serializer;
     std::unique_ptr<core::Packager> packager;
+    std::filesystem::path tplRoot;
     core::Project currentProject;
 };
 


### PR DESCRIPTION
## Summary
- keep template directory path as a MainWindow member
- pass template root when writing preview install script

## Testing
- `g++ -std=c++17 tests/script_writer_test.cpp FirmwarePackager/src/core/ScriptWriter.cpp FirmwarePackager/src/core/IdGenerator.cpp FirmwarePackager/src/core/ProjectModel.cpp -IFirmwarePackager/src -I/usr/src/googletest/googletest/include -L/usr/lib/x86_64-linux-gnu -lgtest -lgtest_main -pthread -o script_writer_test`
- `./script_writer_test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68bfe57ee1ec8327bbc89264c7ea838b