### PR TITLE
Add installation status tracking and recovery logic

### DIFF
--- a/FirmwarePackager/templates/scripts/install.sh.in
+++ b/FirmwarePackager/templates/scripts/install.sh.in
@@ -36,6 +36,7 @@ STEP=""
 LAST_FILE=""
 STORE=""
 RESUME=0
+STATUS="IN_PROGRESS"
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -60,6 +61,7 @@ STEP=$STEP
 JOURNAL=$JOURNAL_FILE
 PKG_TGZ=$PKG_TGZ
 LAST_FILE=$LAST_FILE
+STATUS=$STATUS
 STATE
 }
 
@@ -100,6 +102,7 @@ release_lock() {
 fail() {
     trap - EXIT
     STEP="FAILED"
+    STATUS="FAIL"
     write_state
     rollback
     release_lock
@@ -141,11 +144,13 @@ if [ "$RESUME" -eq 1 ]; then
         : > "$JOURNAL_FILE"
         STEP="PREPARE"
         LAST_FILE=""
+        STATUS="IN_PROGRESS"
         write_state
     fi
 else
     : > "$JOURNAL_FILE"
     STEP="PREPARE"
+    STATUS="IN_PROGRESS"
     write_state
 fi
 
@@ -241,6 +246,7 @@ fi
 trap - EXIT
 STEP="DONE"
 LAST_FILE=""
+STATUS="SUCCESS"
 write_state
 cleanup_success
 exit 0

--- a/FirmwarePackager/templates/scripts/recover_boot.sh.in
+++ b/FirmwarePackager/templates/scripts/recover_boot.sh.in
@@ -10,9 +10,9 @@ JOURNAL_DIR="/opt/upgrade/journal"
 for st in "$STATE_DIR"/*.state; do
     [ -e "$st" ] || continue
 
-    # Skip packages that have already finished
-    step=$(grep '^STEP=' "$st" | cut -d= -f2)
-    if [ "$step" = "DONE" ] || [ "$step" = "FAILED" ]; then
+    # Skip packages that finished successfully
+    status=$(grep '^STATUS=' "$st" | cut -d= -f2)
+    if [ "$status" = "SUCCESS" ]; then
         continue
     fi
 

--- a/tests/install_script_test.cpp
+++ b/tests/install_script_test.cpp
@@ -76,6 +76,7 @@ TEST(InstallScript, DetectsMd5Mismatch){
     std::ifstream st("/opt/upgrade/state/TESTPKG.state");
     std::stringstream s; s<<st.rdbuf();
     EXPECT_NE(s.str().find("STEP=FAILED"), std::string::npos);
+    EXPECT_NE(s.str().find("STATUS=FAIL"), std::string::npos);
     cleanupState();
     remove(archive);
     remove_all(pkg);

--- a/tests/recover_boot_script_test.cpp
+++ b/tests/recover_boot_script_test.cpp
@@ -15,7 +15,7 @@ TEST(RecoverBootScript, RunsInstallWithResumeAndKeepsState) {
 
     std::string id = "testpkg";
     path stateFile = stateDir / (id + ".state");
-    { std::ofstream(stateFile) << "STEP=PREPARE\n"; }
+    { std::ofstream(stateFile) << "STEP=PREPARE\nSTATUS=IN_PROGRESS\n"; }
 
     path temp = temp_directory_path() / "recover_pkg";
     remove_all(temp);
@@ -66,7 +66,7 @@ TEST(RecoverBootScript, SkipsFinishedInstallations) {
 
     std::string id = "testpkg";
     path stateFile = stateDir / (id + ".state");
-    { std::ofstream(stateFile) << "STEP=DONE\n"; }
+    { std::ofstream(stateFile) << "STEP=DONE\nSTATUS=SUCCESS\n"; }
 
     path temp = temp_directory_path() / "recover_pkg";
     remove_all(temp);
@@ -102,7 +102,7 @@ TEST(RecoverBootScript, SkipsFinishedInstallations) {
     remove_all(stateDir);
 }
 
-TEST(RecoverBootScript, SkipsFailedInstallations) {
+TEST(RecoverBootScript, RetriesFailedInstallations) {
     path stateDir = "/opt/upgrade/state";
     path pkgDir = "/opt/upgrade/packages";
     remove_all(stateDir);
@@ -112,7 +112,7 @@ TEST(RecoverBootScript, SkipsFailedInstallations) {
 
     std::string id = "testpkg";
     path stateFile = stateDir / (id + ".state");
-    { std::ofstream(stateFile) << "STEP=FAILED\n"; }
+    { std::ofstream(stateFile) << "STEP=FAILED\nSTATUS=FAIL\n"; }
 
     path temp = temp_directory_path() / "recover_pkg";
     remove_all(temp);
@@ -140,7 +140,7 @@ TEST(RecoverBootScript, SkipsFailedInstallations) {
 
     ASSERT_EQ(std::system(script.string().c_str()), 0);
 
-    EXPECT_FALSE(exists("/tmp/install_called"));
+    EXPECT_TRUE(exists("/tmp/install_called"));
     remove("/tmp/install_called");
 
     remove_all(temp);
@@ -158,7 +158,7 @@ TEST(RecoverBootScript, LeavesTempDirOnInstallError) {
 
     std::string id = "testpkg";
     path stateFile = stateDir / (id + ".state");
-    { std::ofstream(stateFile) << "STEP=PREPARE\n"; }
+    { std::ofstream(stateFile) << "STEP=PREPARE\nSTATUS=IN_PROGRESS\n"; }
 
     path baseTmp = temp_directory_path() / "recover_pkg_err";
     remove_all(baseTmp);


### PR DESCRIPTION
## Summary
- Record installation STATUS in install script and update it to IN_PROGRESS, FAIL, or SUCCESS as the process runs
- Recover script now bases retry decisions on STATUS instead of STEP
- Tests updated to verify STATUS handling and retry failed installs

## Testing
- `g++ -std=c++17 tests/install_script_test.cpp -lcrypto -lgtest -lpthread -o /tmp/install_script_test && /tmp/install_script_test >/tmp/install_script_test.log && tail -n 20 /tmp/install_script_test.log`
- `g++ -std=c++17 tests/recover_boot_script_test.cpp -lgtest -lpthread -o /tmp/recover_boot_script_test && /tmp/recover_boot_script_test >/tmp/recover_boot_script_test.log && tail -n 20 /tmp/recover_boot_script_test.log`


------
https://chatgpt.com/codex/tasks/task_e_68bfe9bc00d4832793b79e1aee505dda