### PR TITLE
Skip failed packages during recovery

### DIFF
--- a/FirmwarePackager/templates/scripts/recover_boot.sh.in
+++ b/FirmwarePackager/templates/scripts/recover_boot.sh.in
@@ -10,9 +10,9 @@ JOURNAL_DIR="/opt/upgrade/journal"
 for st in "$STATE_DIR"/*.state; do
     [ -e "$st" ] || continue
 
-    # Skip packages that finished successfully
+    # Skip packages that finished successfully or failed explicitly
     status=$(grep '^STATUS=' "$st" | cut -d= -f2)
-    if [ "$status" = "SUCCESS" ]; then
+    if [ "$status" = "SUCCESS" ] || [ "$status" = "FAIL" ]; then
         continue
     fi
 

--- a/tests/recover_boot_script_test.cpp
+++ b/tests/recover_boot_script_test.cpp
@@ -102,7 +102,7 @@ TEST(RecoverBootScript, SkipsFinishedInstallations) {
     remove_all(stateDir);
 }
 
-TEST(RecoverBootScript, RetriesFailedInstallations) {
+TEST(RecoverBootScript, SkipsFailedInstallations) {
     path stateDir = "/opt/upgrade/state";
     path pkgDir = "/opt/upgrade/packages";
     remove_all(stateDir);
@@ -140,7 +140,7 @@ TEST(RecoverBootScript, RetriesFailedInstallations) {
 
     ASSERT_EQ(std::system(script.string().c_str()), 0);
 
-    EXPECT_TRUE(exists("/tmp/install_called"));
+    EXPECT_FALSE(exists("/tmp/install_called"));
     remove("/tmp/install_called");
 
     remove_all(temp);


### PR DESCRIPTION
## Summary
- skip reinstalling packages whose status is FAIL during boot recovery
- test that failed installations are ignored

## Testing
- `g++ -std=c++17 tests/recover_boot_script_test.cpp -lgtest -lgtest_main -lpthread -o recover_boot_script_test`
- `./recover_boot_script_test`


------
https://chatgpt.com/codex/tasks/task_e_68bfeefdf7a08327a0c9ee6dc23e14a4