### PR TITLE
Add upgrade recovery init hook

### DIFF
--- a/FirmwarePackager/templates/scripts/init/sysv/S95-upgrade-recover
+++ b/FirmwarePackager/templates/scripts/init/sysv/S95-upgrade-recover
@@ -7,10 +7,9 @@
 # Default-Stop:
 # Short-Description: Run recovery after upgrade
 ### END INIT INFO
-LAST_DIR="/opt/upgrade/last"
 case "$1" in
     start)
-        "$LAST_DIR/scripts/recover_boot.sh"
+        /opt/upgrade/last/scripts/recover_boot.sh
         ;;
     *)
         echo "Usage: $0 start" >&2

--- a/tests/packager_test.cpp
+++ b/tests/packager_test.cpp
@@ -94,6 +94,9 @@ TEST(PackagerTest, GeneratesArchiveWithExpectedContents) {
     EXPECT_NE(script.find(project.version), std::string::npos);
     EXPECT_EQ(script.find("@PKG_NAME@"), std::string::npos);
 
+    path hookPath = packageDir / "scripts" / "init" / "sysv" / "S95-upgrade-recover";
+    EXPECT_TRUE(exists(hookPath));
+
     remove_all(root);
     remove_all(out);
     remove_all(extractDir);


### PR DESCRIPTION
## Summary
- add minimal `S95-upgrade-recover` init hook that runs `recover_boot.sh`
- ensure package archive includes the recovery hook
- test installer deploys hook to init directories

## Testing
- `./build/script_writer_test`
- `./build/packager_test`
- `./build/install_script_test`
- `./build/recover_boot_script_test`


------
https://chatgpt.com/codex/tasks/task_e_68bff0b9db008327a828d71bde0dfaf1