### PR TITLE
Handle rollback status in upgrade scripts

### DIFF
--- a/FirmwarePackager/templates/scripts/install.sh.in
+++ b/FirmwarePackager/templates/scripts/install.sh.in
@@ -66,6 +66,8 @@ STATE
 }
 
 rollback() {
+    STATUS="ROLLBACK"
+    write_state
     [ -f "$JOURNAL_FILE" ] || return 0
     awk '{l[NR]=$0} END{for(i=NR;i>=1;i--) print l[i]}' "$JOURNAL_FILE" | \
     while IFS="|" read -r action dest backup; do
@@ -102,9 +104,9 @@ release_lock() {
 fail() {
     trap - EXIT
     STEP="FAILED"
+    rollback
     STATUS="FAIL"
     write_state
-    rollback
     release_lock
     exit 1
 }
@@ -243,10 +245,12 @@ if [ "$STEP" = "BACKUP" ]; then
     write_state
 fi
 
-trap - EXIT
-STEP="DONE"
-LAST_FILE=""
-STATUS="SUCCESS"
-write_state
-cleanup_success
-exit 0
+if [ "$STEP" = "COMMIT" ]; then
+    trap - EXIT
+    STEP="DONE"
+    LAST_FILE=""
+    STATUS="SUCCESS"
+    write_state
+    cleanup_success
+    exit 0
+fi

--- a/FirmwarePackager/templates/scripts/recover_boot.sh.in
+++ b/FirmwarePackager/templates/scripts/recover_boot.sh.in
@@ -24,7 +24,17 @@ for st in "$STATE_DIR"/*.state; do
     tar -xzf "$ARCHIVE" -C "$TMP"
 
     if [ -f "$TMP/package/scripts/install.sh" ]; then
-        if (
+        if [ "$status" = "ROLLBACK" ]; then
+            if ! (cd "$TMP/package" && ./scripts/install.sh --resume); then
+                echo "Installation failed for $ID; leaving $TMP for inspection" >&2
+                exit 1
+            fi
+            if ! (cd "$TMP/package" && ./scripts/install.sh --resume); then
+                echo "Installation failed for $ID; leaving $TMP for inspection" >&2
+                exit 1
+            fi
+            rm -rf "$TMP"
+        elif (
             cd "$TMP/package" && ./scripts/install.sh --resume
         ); then
             rm -rf "$TMP"

--- a/docs/state_machine.md
+++ b/docs/state_machine.md
@@ -19,6 +19,19 @@ state machine.  Progress is persisted under `/opt/upgrade/state` and
 * **FAILED** – An error occurred and rollback was executed. The state
   file is kept for inspection.
 
+In addition to the step above, the state file contains a `STATUS`
+field describing the overall progress. Valid values are:
+
+* `IN_PROGRESS` – Normal upgrade flow.
+* `ROLLBACK` – A rollback is in progress before the upgrade is
+  attempted again.
+* `SUCCESS` – Upgrade completed successfully.
+* `FAIL` – Upgrade failed even after rollback.
+
+When `recover_boot.sh` encounters a state file with `STATUS=ROLLBACK`,
+it invokes the package's `install.sh` script twice: first to complete
+the rollback and then again to restart the upgrade process.
+
 The current step is stored in `/opt/upgrade/state/<PKG_ID>.state` which
 contains the fields `STEP`, `JOURNAL`, `PKG_TGZ` and `LAST_FILE`.
 `recover_boot.sh` scans this directory on boot and replays unfinished


### PR DESCRIPTION
## Summary
- add rollback status handling and commit step in `install.sh`
- extend recovery script to process `STATUS=ROLLBACK`
- document new rollback status and flow
- test recovery script for rollback execution

## Testing
- `g++ -std=c++17 tests/recover_boot_script_test.cpp ... && /tmp/recover_boot_script_test`
- `g++ -std=c++17 tests/install_script_test.cpp ... && /tmp/install_script_test`
- `g++ -std=c++17 tests/manifest_writer_test.cpp ... && /tmp/manifest_writer_test`
- `g++ -std=c++17 tests/hasher_test.cpp ... && /tmp/hasher_test`
- `g++ -std=c++17 tests/id_generator_test.cpp ... && /tmp/id_generator_test`
- `g++ -std=c++17 tests/script_writer_test.cpp ... && /tmp/script_writer_test`
- `g++ -std=c++17 tests/scanner_test.cpp ... && /tmp/scanner_test`
- `g++ -std=c++17 tests/project_serializer_test.cpp ... && /tmp/project_serializer_test`
- `g++ -std=c++17 tests/packager_test.cpp ... && /tmp/packager_test`


------
https://chatgpt.com/codex/tasks/task_e_68bff4994c9c8327b6be29305ede47db