### PR TITLE
Gracefully handle lock acquisition failure

### DIFF
--- a/FirmwarePackager/templates/scripts/install.sh.in
+++ b/FirmwarePackager/templates/scripts/install.sh.in
@@ -94,7 +94,7 @@ rollback() {
 }
 
 acquire_lock() {
-    ln -s "$$" "$LOCK_FILE" 2>/dev/null
+    ln -s "$$" "$LOCK_FILE" 2>/dev/null || return 1
 }
 
 release_lock() {


### PR DESCRIPTION
## Summary
- ensure `acquire_lock` returns a failure status instead of exiting by linking with `|| return 1`

## Testing
- `/tmp/install_script_test`
- `/tmp/hasher_test`
- `/tmp/recover_boot_script_test`


------
https://chatgpt.com/codex/tasks/task_e_68bff834a07c83278c453bce30d8c0a1