### PR TITLE
Refactor packager to accept externally-built projects

### DIFF
--- a/FirmwarePackager/src/core/Packager.h
+++ b/FirmwarePackager/src/core/Packager.h
@@ -14,8 +14,7 @@ namespace core {
 class IPackager {
 public:
     virtual ~IPackager() = default;
-    virtual Project buildProject(const std::filesystem::path& root, const Scanner::PathList& exclusions) = 0;
-    virtual void package(const Project& project) = 0;
+    virtual void package(const Project* project) = 0;
 };
 
 class Packager : public IPackager {
@@ -24,8 +23,7 @@ public:
              IScriptWriter& script, IIdGenerator& idGen, ILogger& logger,
              std::filesystem::path templateRoot);
 
-    Project buildProject(const std::filesystem::path& root, const Scanner::PathList& exclusions) override;
-    void package(const Project& project) override;
+    void package(const Project* project) override;
 
 private:
     Scanner& scanner;

--- a/FirmwarePackager/src/ui/MainWindow.h
+++ b/FirmwarePackager/src/ui/MainWindow.h
@@ -32,6 +32,8 @@ private slots:
 
 private:
     void populateTable(const core::Project& project);
+    core::Project buildProject(const std::filesystem::path& root,
+                               const core::Scanner::PathList& exclusions = {});
 
     QTableView* tableView;
     QStandardItemModel* model;

--- a/tests/packager_test.cpp
+++ b/tests/packager_test.cpp
@@ -51,7 +51,7 @@ TEST(PackagerTest, GeneratesArchiveWithExpectedContents) {
     remove_all(tmpCwd);
     create_directories(tmpCwd);
     current_path(tmpCwd);
-    pack.package(project);
+    pack.package(&project);
     current_path(cwd);
 
     path archive = out / (project.name + ".tar.gz");


### PR DESCRIPTION
## Summary
- Remove buildProject from IPackager and use Project pointer for packaging
- Update Packager and callers to accept Project pointers
- Build projects externally in UI and adjust tests

## Testing
- `g++ -std=c++17 tests/packager_test.cpp FirmwarePackager/src/core/Hasher.cpp FirmwarePackager/src/core/ManifestWriter.cpp FirmwarePackager/src/core/Packager.cpp FirmwarePackager/src/core/ProjectModel.cpp FirmwarePackager/src/core/ProjectSerializer.cpp FirmwarePackager/src/core/Scanner.cpp FirmwarePackager/src/core/ScriptWriter.cpp FirmwarePackager/src/core/IdGenerator.cpp FirmwarePackager/src/core/Logger.cpp FirmwarePackager/third_party/googletest-1.17.0/googletest/src/gtest-all.cc -Itests -IFirmwarePackager/src -IFirmwarePackager/third_party/googletest-1.17.0/googletest -IFirmwarePackager/third_party/googletest-1.17.0/googletest/include -pthread -larchive -lcrypto -o packager_test`
- `./packager_test`


------
https://chatgpt.com/codex/tasks/task_e_68c4002f134483279d5eb21b1c19a964